### PR TITLE
Set $wgSecretKey in base and bundle LocalSettings.php 

### DIFF
--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -34,6 +34,7 @@ services:
       - DB_NAME=my_wiki
       - MW_ADMIN_NAME=admin
       - MW_ADMIN_PASS=adminpass
+      - MW_WG_SECRET_KEY=secretkey
   mysql:
     image: mariadb:latest
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       - DB_NAME=my_wiki
       - MW_ADMIN_NAME=admin
       - MW_ADMIN_PASS=adminpass
+      - MW_WG_SECRET_KEY=secretkey
   mysql:
     image: mariadb:latest
     restart: always

--- a/wikibase/1.30/base/Dockerfile
+++ b/wikibase/1.30/base/Dockerfile
@@ -38,5 +38,5 @@ RUN ln -s /var/www/html/ /var/www/html/w
 ENV MW_SITE_NAME=wikibase-docker\
     MW_SITE_LANG=en
 
-ENTRYPOINT ["/bin/sh"]
+ENTRYPOINT ["/bin/bash"]
 CMD ["/entrypoint.sh"]

--- a/wikibase/1.30/base/LocalSettings.php.template
+++ b/wikibase/1.30/base/LocalSettings.php.template
@@ -35,6 +35,9 @@ ${DOLLAR}wgMetaNamespace = "Project";
 ${DOLLAR}wgScriptPath = "/w";        // this should already have been configured this way
 ${DOLLAR}wgArticlePath = "/wiki/${DOLLAR}1";
 
+#Set Secret
+${DOLLAR}wgSecretKey = "${MW_WG_SECRET_KEY}";
+
 ## RC Age
 # https://www.mediawiki.org/wiki/Manual:$wgRCMaxAge
 # Items in the recentchanges table are periodically purged; entries older than this many seconds will go.

--- a/wikibase/1.30/base/entrypoint.sh
+++ b/wikibase/1.30/base/entrypoint.sh
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 # This file is provided by the wikibase/wikibase docker image.
 
 # Test if required environment variables have been set
-REQUIRED_VARIABLES=(MW_ADMIN_NAME MW_ADMIN_PASS DB_SERVER DB_USER DB_PASS DB_NAME)
+REQUIRED_VARIABLES=(MW_ADMIN_NAME MW_ADMIN_PASS MW_WG_SECRET_KEY DB_SERVER DB_USER DB_PASS DB_NAME)
 for i in ${REQUIRED_VARIABLES[@]}; do
     eval THISSHOULDBESET=\$$i
     if [ -z "$THISSHOULDBESET" ]; then

--- a/wikibase/README.md
+++ b/wikibase/README.md
@@ -43,6 +43,7 @@ Variable          | Default              | Description
 `MW_SITE_LANG`    | "en"                 | $wgLanguageCode to use for MediaWiki
 `MW_ADMIN_NAME`   | "admin"              | Admin username to create on MediaWiki first install
 `MW_ADMIN_PASS`   | "adminpass"          | Admin password to use for admin account on first install
+`MW_WG_SECRET_KEY`| "secretkey"          | Used as source of entropy for persistent login/Oauth etc..
 
 ### Filesystem layout
 


### PR DESCRIPTION
Use ENV to set a default value for $wgSecretKey in the templated
local settings. This helps make sure "stay logged in" and OAuth
works as it should.

Normally this would be set by the Installer to a random value.
User may was to set the ENV themselves to a real secret.

Bug: T193405

This depends on adding the wikibase bundle image.