### PR TITLE
Remove ENV vars at build time enforce presence at runtime

### DIFF
--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -27,6 +27,13 @@ services:
       default:
         aliases:
          - wikibase.svc
+    environment:
+      - DB_SERVER=mysql.svc:3306
+      - DB_USER=wikiuser
+      - DB_PASS=sqlpass
+      - DB_NAME=my_wiki
+      - MW_ADMIN_NAME=admin
+      - MW_ADMIN_PASS=adminpass
   mysql:
     image: mariadb:latest
     volumes:
@@ -53,6 +60,9 @@ services:
       default:
         aliases:
          - wdqs-frontend.svc
+    environment:
+      - WIKIBASE_HOST=wikibase.svc
+      - WDQS_HOST=wdqs-proxy.svc
   wdqs:
     image: wikibase/wdqs:0.3.0
     restart: always
@@ -66,6 +76,12 @@ services:
       default:
         aliases:
          - wdqs.svc
+    environment:
+      - WIKIBASE_HOST=wikibase.svc
+      - WDQS_HOST=wdqs.svc
+      - WDQS_PORT=9999
+    expose:
+      - 9999
   wdqs-proxy:
     image: wikibase/wdqs-proxy
     build:
@@ -94,6 +110,10 @@ services:
       default:
         aliases:
          - wdqs-updater.svc
+    environment:
+     - WIKIBASE_HOST=wikibase.svc
+     - WDQS_HOST=wdqs.svc
+     - WDQS_PORT=9999
 
 volumes:
   mediawiki-mysql-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,13 @@ services:
       default:
         aliases:
          - wikibase.svc
+    environment:
+      - DB_SERVER=mysql.svc:3306
+      - DB_USER=wikiuser
+      - DB_PASS=sqlpass
+      - DB_NAME=my_wiki
+      - MW_ADMIN_NAME=admin
+      - MW_ADMIN_PASS=adminpass
   mysql:
     image: mariadb:latest
     restart: always
@@ -48,6 +55,9 @@ services:
       default:
         aliases:
          - wdqs-frontend.svc
+    environment:
+      - WIKIBASE_HOST=wikibase.svc
+      - WDQS_HOST=wdqs-proxy.svc
   wdqs:
     image: wikibase/wdqs:0.3.0
     volumes:
@@ -57,6 +67,10 @@ services:
       default:
         aliases:
          - wdqs.svc
+    environment:
+      - WIKIBASE_HOST=wikibase.svc
+      - WDQS_HOST=wdqs.svc
+      - WDQS_PORT=9999
     expose:
       - 9999
   wdqs-proxy:
@@ -81,6 +95,10 @@ services:
       default:
         aliases:
          - wdqs-updater.svc
+    environment:
+     - WIKIBASE_HOST=wikibase.svc
+     - WDQS_HOST=wdqs.svc
+     - WDQS_PORT=9999
 
 volumes:
   mediawiki-mysql-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,8 @@ services:
       default:
         aliases:
          - wdqs.svc
+    expose:
+      - 9999
   wdqs-proxy:
     image: wikibase/wdqs-proxy
     environment:

--- a/wdqs-frontend/latest/Dockerfile
+++ b/wdqs-frontend/latest/Dockerfile
@@ -33,9 +33,7 @@ COPY config.js /templates/config.js
 COPY default.conf /templates/default.conf
 
 ENV LANGUAGE=en\
-    BRAND_TITLE=DockerWikibaseQueryService\
-    WIKIBASE_HOST="wikibase.svc"\
-    WDQS_HOST="wdqs-proxy.svc"
+    BRAND_TITLE=DockerWikibaseQueryService
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]

--- a/wdqs-frontend/latest/entrypoint.sh
+++ b/wdqs-frontend/latest/entrypoint.sh
@@ -2,14 +2,15 @@
 # This file is provided by the wikibase/wdqs-frontend docker image.
 
 # Test if required environment variables have been set
-REQUIRED_VARIABLES=(WIKIBASE_HOST WDQS_HOST)
-for i in ${REQUIRED_VARIABLES[@]}; do
-    eval THISSHOULDBESET=\$$i
-    if [ -z "$THISSHOULDBESET" ]; then
-    echo "$i is required but isn't set. You can pass it using either plain docker or docker-compose";
-    exit 1;
-    fi
-done
+if [ -z "$WIKIBASE_HOST" ]; then
+echo "WIKIBASE_HOST is required but isn't set. You can pass it using either plain docker or docker-compose";
+exit 1;
+fi
+
+if [ -z "$WDQS_HOST" ]; then
+echo "WDQS_HOST is required but isn't set. You can pass it using either plain docker or docker-compose";
+exit 1;
+fi
 
 set -eu
 

--- a/wdqs-frontend/latest/entrypoint.sh
+++ b/wdqs-frontend/latest/entrypoint.sh
@@ -1,6 +1,16 @@
 #!/bin/sh
 # This file is provided by the wikibase/wdqs-frontend docker image.
 
+# Test if required environment variables have been set
+REQUIRED_VARIABLES=(WIKIBASE_HOST WDQS_HOST)
+for i in ${REQUIRED_VARIABLES[@]}; do
+    eval THISSHOULDBESET=\$$i
+    if [ -z "$THISSHOULDBESET" ]; then
+    echo "$i is required but isn't set. You can pass it using either plain docker or docker-compose";
+    exit 1;
+    fi
+done
+
 set -eu
 
 export DOLLAR='$'

--- a/wdqs-frontend/latest/entrypoint.sh
+++ b/wdqs-frontend/latest/entrypoint.sh
@@ -3,12 +3,12 @@
 
 # Test if required environment variables have been set
 if [ -z "$WIKIBASE_HOST" ]; then
-echo "WIKIBASE_HOST is required but isn't set. You can pass it using either plain docker or docker-compose";
+echo "WIKIBASE_HOST is required but isn't set. You should pass it to docker. See: https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file";
 exit 1;
 fi
 
 if [ -z "$WDQS_HOST" ]; then
-echo "WDQS_HOST is required but isn't set. You can pass it using either plain docker or docker-compose";
+echo "WDQS_HOST is required but isn't set. You should pass it to docker. See: https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file";
 exit 1;
 fi
 

--- a/wdqs-proxy/latest/entrypoint.sh
+++ b/wdqs-proxy/latest/entrypoint.sh
@@ -3,7 +3,7 @@
 
 # Test if required environment variables have been set
 if [ -z "$PROXY_PASS_HOST" ]; then
-echo "PROXY_PASS_HOST is required but isn't set. You can pass it using either plain docker or docker-compose";
+echo "PROXY_PASS_HOST is required but isn't set. You should pass it to docker. See: https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file";
 exit 1;
 fi
 

--- a/wdqs-proxy/latest/entrypoint.sh
+++ b/wdqs-proxy/latest/entrypoint.sh
@@ -1,6 +1,16 @@
 #!/bin/sh
 # This file is provided by the wikibase/wdqs-proxy docker image.
 
+# Test if required environment variables have been set
+REQUIRED_VARIABLES=(PROXY_PASS_HOST)
+for i in ${REQUIRED_VARIABLES[@]}; do
+    eval THISSHOULDBESET=\$$i
+    if [ -z "$THISSHOULDBESET" ]; then
+    echo "$i is required but isn't set. You can pass it using either plain docker or docker-compose";
+    exit 1;
+    fi
+done
+
 set -eu
 
 envsubst < /etc/nginx/conf.d/wdqs.template > /etc/nginx/conf.d/default.conf

--- a/wdqs-proxy/latest/entrypoint.sh
+++ b/wdqs-proxy/latest/entrypoint.sh
@@ -2,14 +2,10 @@
 # This file is provided by the wikibase/wdqs-proxy docker image.
 
 # Test if required environment variables have been set
-REQUIRED_VARIABLES=(PROXY_PASS_HOST)
-for i in ${REQUIRED_VARIABLES[@]}; do
-    eval THISSHOULDBESET=\$$i
-    if [ -z "$THISSHOULDBESET" ]; then
-    echo "$i is required but isn't set. You can pass it using either plain docker or docker-compose";
-    exit 1;
-    fi
-done
+if [ -z "$PROXY_PASS_HOST" ]; then
+echo "PROXY_PASS_HOST is required but isn't set. You can pass it using either plain docker or docker-compose";
+exit 1;
+fi
 
 set -eu
 

--- a/wdqs/0.2.5/Dockerfile
+++ b/wdqs/0.2.5/Dockerfile
@@ -22,13 +22,8 @@ COPY --from=fetcher /service-0.2.5 /wdqs
 ENV MEMORY=""\
     HEAP_SIZE="1g"\
     HOST="0.0.0.0"\
-    WIKIBASE_HOST="wikibase.svc"\
-    WDQS_HOST="wdqs.svc"\
-    WDQS_PORT="9999"\
     WDQS_ENTITY_NAMESPACES="120,122"\
     WIKIBASE_SCHEME="http"
-
-EXPOSE $WDQS_PORT
 
 WORKDIR "/wdqs/"
 

--- a/wdqs/0.2.5/entrypoint.sh
+++ b/wdqs/0.2.5/entrypoint.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 # This file is provided by the wikibase/wdqs docker image.
 
+# Test if required environment variables have been set
+REQUIRED_VARIABLES=(WIKIBASE_HOST WDQS_HOST WDQS_PORT)
+for i in ${REQUIRED_VARIABLES[@]}; do
+    eval THISSHOULDBESET=\$$i
+    if [ -z "$THISSHOULDBESET" ]; then
+    echo "$i is required but isn't set. You can pass it using either plain docker or docker-compose";
+    exit 1;
+    fi
+done
+
 set -eu
 
 export BLAZEGRAPH_OPTS="-DwikibaseHost=${WIKIBASE_HOST}"

--- a/wdqs/0.2.5/entrypoint.sh
+++ b/wdqs/0.2.5/entrypoint.sh
@@ -6,7 +6,7 @@ REQUIRED_VARIABLES=(WIKIBASE_HOST WDQS_HOST WDQS_PORT)
 for i in ${REQUIRED_VARIABLES[@]}; do
     eval THISSHOULDBESET=\$$i
     if [ -z "$THISSHOULDBESET" ]; then
-    echo "$i is required but isn't set. You can pass it using either plain docker or docker-compose";
+    echo "$i is required but isn't set. You should pass it to docker. See: https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file";
     exit 1;
     fi
 done

--- a/wdqs/0.3.0/Dockerfile
+++ b/wdqs/0.3.0/Dockerfile
@@ -22,9 +22,6 @@ COPY --from=fetcher /service-0.3.0 /wdqs
 ENV MEMORY=""\
     HEAP_SIZE="1g"\
     HOST="0.0.0.0"\
-    WIKIBASE_HOST="wikibase.svc"\
-    WDQS_HOST="wdqs.svc"\
-    WDQS_PORT="9999"\
     WDQS_ENTITY_NAMESPACES="120,122"\
     WIKIBASE_SCHEME="http"
 

--- a/wdqs/0.3.0/Dockerfile
+++ b/wdqs/0.3.0/Dockerfile
@@ -25,8 +25,6 @@ ENV MEMORY=""\
     WDQS_ENTITY_NAMESPACES="120,122"\
     WIKIBASE_SCHEME="http"
 
-EXPOSE $WDQS_PORT
-
 WORKDIR "/wdqs/"
 
 COPY wait-for-it.sh /wait-for-it.sh

--- a/wdqs/0.3.0/entrypoint.sh
+++ b/wdqs/0.3.0/entrypoint.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 # This file is provided by the wikibase/wdqs docker image.
 
+# Test if required environment variables have been set
+REQUIRED_VARIABLES=(WIKIBASE_HOST WDQS_HOST WDQS_PORT)
+for i in ${REQUIRED_VARIABLES[@]}; do
+    eval THISSHOULDBESET=\$$i
+    if [ -z "$THISSHOULDBESET" ]; then
+    echo "$i is required but isn't set. You can pass it using either plain docker or docker-compose";
+    exit 1;
+    fi
+done
+
 set -eu
 
 export BLAZEGRAPH_OPTS="-DwikibaseHost=${WIKIBASE_HOST}"

--- a/wdqs/0.3.0/entrypoint.sh
+++ b/wdqs/0.3.0/entrypoint.sh
@@ -6,7 +6,7 @@ REQUIRED_VARIABLES=(WIKIBASE_HOST WDQS_HOST WDQS_PORT)
 for i in ${REQUIRED_VARIABLES[@]}; do
     eval THISSHOULDBESET=\$$i
     if [ -z "$THISSHOULDBESET" ]; then
-    echo "$i is required but isn't set. You can pass it using either plain docker or docker-compose";
+    echo "$i is required but isn't set. You should pass it to docker. See: https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file";
     exit 1;
     fi
 done

--- a/wikibase/1.29/Dockerfile
+++ b/wikibase/1.29/Dockerfile
@@ -35,14 +35,9 @@ COPY htaccess /var/www/html/.htaccess
 
 RUN ln -s /var/www/html/ /var/www/html/w
 
-ENV DB_SERVER=mysql.svc:3306\
-    DB_USER=wikiuser\
-    DB_PASS=sqlpass\
-    DB_NAME=my_wiki\
-    MW_SITE_NAME=wikibase-docker\
-    MW_SITE_LANG=en\
-    MW_ADMIN_NAME=admin\
-    MW_ADMIN_PASS=adminpass
+ENV MW_SITE_NAME=wikibase-docker\
+    MW_SITE_LANG=en
+
 
 ENTRYPOINT ["/bin/sh"]
 CMD ["/entrypoint.sh"]

--- a/wikibase/1.29/entrypoint.sh
+++ b/wikibase/1.29/entrypoint.sh
@@ -1,6 +1,16 @@
 #!/bin/sh
 # This file is provided by the wikibase/wikibase docker image.
 
+# Test if required environment variables have been set
+REQUIRED_VARIABLES=(MW_ADMIN_NAME MW_ADMIN_PASS DB_SERVER DB_USER DB_PASS DB_NAME)
+for i in ${REQUIRED_VARIABLES[@]}; do
+    eval THISSHOULDBESET=\$$i
+    if [ -z "$THISSHOULDBESET" ]; then
+    echo "$i is required but isn't set. You can pass it using either plain docker or docker-compose";
+    exit 1;
+    fi
+done
+
 set -eu
 
 # Wait for the db to come up

--- a/wikibase/1.29/entrypoint.sh
+++ b/wikibase/1.29/entrypoint.sh
@@ -6,7 +6,7 @@ REQUIRED_VARIABLES=(MW_ADMIN_NAME MW_ADMIN_PASS DB_SERVER DB_USER DB_PASS DB_NAM
 for i in ${REQUIRED_VARIABLES[@]}; do
     eval THISSHOULDBESET=\$$i
     if [ -z "$THISSHOULDBESET" ]; then
-    echo "$i is required but isn't set. You can pass it using either plain docker or docker-compose";
+    echo "$i is required but isn't set. You should pass it to docker. See: https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file";
     exit 1;
     fi
 done

--- a/wikibase/1.30/base/Dockerfile
+++ b/wikibase/1.30/base/Dockerfile
@@ -35,14 +35,8 @@ COPY htaccess /var/www/html/.htaccess
 
 RUN ln -s /var/www/html/ /var/www/html/w
 
-ENV DB_SERVER=mysql.svc:3306\
-    DB_USER=wikiuser\
-    DB_PASS=sqlpass\
-    DB_NAME=my_wiki\
-    MW_SITE_NAME=wikibase-docker\
-    MW_SITE_LANG=en\
-    MW_ADMIN_NAME=admin\
-    MW_ADMIN_PASS=adminpass
+ENV MW_SITE_NAME=wikibase-docker\
+    MW_SITE_LANG=en
 
 ENTRYPOINT ["/bin/sh"]
 CMD ["/entrypoint.sh"]

--- a/wikibase/1.30/base/entrypoint.sh
+++ b/wikibase/1.30/base/entrypoint.sh
@@ -1,6 +1,16 @@
 #!/bin/sh
 # This file is provided by the wikibase/wikibase docker image.
 
+# Test if required environment variables have been set
+REQUIRED_VARIABLES=(MW_ADMIN_NAME MW_ADMIN_PASS DB_SERVER DB_USER DB_PASS DB_NAME)
+for i in ${REQUIRED_VARIABLES[@]}; do
+    eval THISSHOULDBESET=\$$i
+    if [ -z "$THISSHOULDBESET" ]; then
+    echo "$i is required but isn't set. You can pass it using either plain docker or docker-compose";
+    exit 1;
+    fi
+done
+
 set -eu
 
 # Wait for the db to come up

--- a/wikibase/1.30/base/entrypoint.sh
+++ b/wikibase/1.30/base/entrypoint.sh
@@ -6,7 +6,7 @@ REQUIRED_VARIABLES=(MW_ADMIN_NAME MW_ADMIN_PASS DB_SERVER DB_USER DB_PASS DB_NAM
 for i in ${REQUIRED_VARIABLES[@]}; do
     eval THISSHOULDBESET=\$$i
     if [ -z "$THISSHOULDBESET" ]; then
-    echo "$i is required but isn't set. You can pass it using either plain docker or docker-compose";
+    echo "$i is required but isn't set. You should pass it to docker. See: https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file";
     exit 1;
     fi
 done


### PR DESCRIPTION
Here is a WIP for the sort of thing I'll do for everything.

I'll then pop all the default in a separate .env file and include those in the docker-compose