### PR TITLE
Make Travis lint Dockerfiles with hadolint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ jobs:
   include:
     - stage: prebuild
       script: bash ./.travis/checkx.sh
+    - stage: prebuild
+      script: bash ./.travis/run-linters.sh
 
 stages:
   - prebuild

--- a/.travis/run-docker-linter.sh
+++ b/.travis/run-docker-linter.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -eu
+
+echo "now linting: $1"
+docker run --rm -i hadolint/hadolint hadolint --ignore DL3006 - < "$1"
+echo "-------"

--- a/.travis/run-linters.sh
+++ b/.travis/run-linters.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+docker pull hadolint/hadolint
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+find ./ -name Dockerfile -print0 | xargs -0 -L1 $DIR/run-docker-linter.sh

--- a/wdqs-frontend/latest/Dockerfile
+++ b/wdqs-frontend/latest/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu as fetcher
 
 RUN apt-get update && \
-    apt-get install --yes --no-install-recommends unzip
+    apt-get install --yes --no-install-recommends unzip=6.0-20ubuntu1
 
 ADD https://github.com/wikimedia/wikidata-query-gui/archive/master.zip ./master.zip
 
@@ -13,14 +13,14 @@ FROM nginx:stable-alpine
 
 COPY --from=fetcher /wikidata-query-gui-master /tmp/wikidata-query-gui-master
 
+WORKDIR /tmp/wikidata-query-gui-master
+
 # Put wdqs gui in the right place
-RUN set -x; \
-    apk --update add --virtual build-dependencies ca-certificates git nodejs jq \
-    && cd /tmp/wikidata-query-gui-master \
+RUN set -x ; \
+    apk --no-cache add --virtual build-dependencies ca-certificates=20161130-r1 git=2.11.3-r0 nodejs=6.9.5-r1 jq=1.5-r4 \
     && mv package.json package.json.orig \
-    && cat package.json.orig \
-        | jq 'delpaths([["devDependencies","karma-qunit"],["devDependencies","qunitjs"],["devDependencies","sinon"]])' \
-        > package.json \
+    && jq 'delpaths([["devDependencies","karma-qunit"],["devDependencies","qunitjs"],["devDependencies","sinon"]])' \
+        > package.json < package.json.orig \
     && npm install \
     && rm -rf /usr/share/nginx/html \
     && mv /tmp/wikidata-query-gui-master /usr/share/nginx/html \

--- a/wdqs/0.2.5/Dockerfile
+++ b/wdqs/0.2.5/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu as fetcher
 
 RUN apt-get update && \
-    apt-get install --yes --no-install-recommends unzip
+    apt-get install --yes --no-install-recommends unzip=6.0-20ubuntu1
 
 ADD https://archiva.wikimedia.org/repository/snapshots/org/wikidata/query/rdf/service/0.2.5-SNAPSHOT/service-0.2.5-SNAPSHOT-dist.zip ./service-dist.zip
 
@@ -12,8 +12,8 @@ FROM openjdk:8-jdk-alpine
 
 # Blazegraph scripts require bash
 # Install gettext for envsubst command, (it needs libintl package)
-RUN set -x; \
-    apk --update add bash gettext libintl
+RUN set -x ; \
+    apk --no-cache add bash=4.4.19-r1 gettext=0.19.8.1-r1 libintl=0.19.8.1-r1
 
 COPY --from=fetcher /service-0.2.5-SNAPSHOT /wdqs
 
@@ -24,7 +24,7 @@ ENV MEMORY=""\
     WDQS_ENTITY_NAMESPACES="120,122"\
     WIKIBASE_SCHEME="http"
 
-WORKDIR "/wdqs/"
+WORKDIR /wdqs
 
 COPY wait-for-it.sh /wait-for-it.sh
 COPY entrypoint.sh /entrypoint.sh

--- a/wdqs/0.3.0/Dockerfile
+++ b/wdqs/0.3.0/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu as fetcher
 
 RUN apt-get update && \
-    apt-get install --yes --no-install-recommends unzip
+    apt-get install --yes --no-install-recommends unzip=6.0-20ubuntu1
 
 ADD https://archiva.wikimedia.org/repository/snapshots/org/wikidata/query/rdf/service/0.3.0-SNAPSHOT/service-0.3.0-SNAPSHOT-dist.zip ./service-dist.zip
 
@@ -12,8 +12,8 @@ FROM openjdk:8-jdk-alpine
 
 # Blazegraph scripts require bash
 # Install gettext for envsubst command, (it needs libintl package)
-RUN set -x; \
-    apk --update add bash gettext libintl
+RUN set -x ; \
+    apk --no-cache add bash=4.4.19-r1 gettext=0.19.8.1-r1 libintl=0.19.8.1-r1
 
 COPY --from=fetcher /service-0.3.0-SNAPSHOT /wdqs
 
@@ -25,7 +25,7 @@ ENV MEMORY=""\
     WIKIBASE_SCHEME="http"\
     WIKIBASE_MAX_DAYS_BACK="90"
 
-WORKDIR "/wdqs/"
+WORKDIR /wdqs
 
 COPY wait-for-it.sh /wait-for-it.sh
 COPY entrypoint.sh /entrypoint.sh

--- a/wikibase/1.29/Dockerfile
+++ b/wikibase/1.29/Dockerfile
@@ -1,26 +1,27 @@
 FROM ubuntu as fetcher
 
 RUN apt-get update && \
-    apt-get install --yes --no-install-recommends unzip
+    apt-get install --yes --no-install-recommends unzip=6.0-20ubuntu1
 
 ADD https://github.com/wikimedia/mediawiki-extensions-Wikibase/archive/REL1_29.zip .
 
 # Creates /mediawiki-extensions-Wikibase-REL1_29
-RUN unzip REL1_29.zip && rm *.zip
+RUN unzip REL1_29.zip && rm ./*.zip
 
 
 FROM composer as composer
 
 COPY --from=fetcher /mediawiki-extensions-Wikibase-REL1_29 /Wikibase
 
-RUN cd /Wikibase && composer install --no-dev
+WORKDIR /Wikibase
+RUN composer install --no-dev
 
 
 FROM mediawiki:1.29
 
 # Install envsubst
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends gettext-base && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends gettext-base=0.19.3-2 && \
     rm -rf /var/lib/apt/lists/*
 
 RUN a2enmod rewrite

--- a/wikibase/1.30/base/Dockerfile
+++ b/wikibase/1.30/base/Dockerfile
@@ -1,26 +1,27 @@
 FROM ubuntu as fetcher
 
 RUN apt-get update && \
-    apt-get install --yes --no-install-recommends unzip
+    apt-get install --yes --no-install-recommends unzip=6.0-20ubuntu1
 
 ADD https://github.com/wikimedia/mediawiki-extensions-Wikibase/archive/REL1_30.zip .
 
 # Creates /mediawiki-extensions-Wikibase-REL1_30
-RUN unzip REL1_30.zip && rm *.zip
+RUN unzip REL1_30.zip && rm ./*.zip
 
 
 FROM composer as composer
 
 COPY --from=fetcher /mediawiki-extensions-Wikibase-REL1_30 /Wikibase
 
-RUN cd /Wikibase && composer install --no-dev
+WORKDIR /Wikibase
+RUN composer install --no-dev
 
 
 FROM mediawiki:1.30
 
 # Install envsubst
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends gettext-base && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends gettext-base=0.19.3-2 && \
     rm -rf /var/lib/apt/lists/*
 
 RUN a2enmod rewrite

--- a/wikibase/1.30/bundle/Dockerfile
+++ b/wikibase/1.30/bundle/Dockerfile
@@ -1,17 +1,17 @@
 FROM ubuntu as fetcher
 
 RUN apt-get update && \
-    apt-get install --yes --no-install-recommends unzip jq curl ca-certificates
-ADD download-extension.sh .
+    apt-get install --yes --no-install-recommends unzip=6.0-20ubuntu1 jq=1.5+dfsg-1 curl=7.47.0-1ubuntu2.8 ca-certificates=20170717~16.04.1
+COPY download-extension.sh .
 RUN bash download-extension.sh OAuth
-RUN tar xzf OAuth.tar.gz && rm *.tar.gz
+RUN tar xzf OAuth.tar.gz && rm ./*.tar.gz
 ADD https://github.com/filbertkm/WikibaseImport/archive/master.tar.gz /WikibaseImport.tar.gz
 RUN tar xzf WikibaseImport.tar.gz
 
-
 FROM composer as composer
 COPY --from=fetcher /WikibaseImport-master /WikibaseImport
-RUN cd /WikibaseImport && composer install --no-dev
+WORKDIR /WikibaseImport
+RUN composer install --no-dev
 
 FROM wikibase/wikibase:1.30
 COPY --from=fetcher /OAuth /var/www/html/extensions/OAuth


### PR DESCRIPTION
Using the dockerized hadolint and fixing up small changes to the docker files to make them pass linting

Mostly changing `cd` to WORKDIR and pinning versions