### PR TITLE
Add quickstatements image and example container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
  - IMAGE_PATH=wdqs/0.3.0/
  - IMAGE_PATH=wdqs-frontend/latest/
  - IMAGE_PATH=wdqs-proxy/latest/
+ - IMAGE_PATH=quickstatements/latest/
 
 script:
  - source ./.travis/docker-push-setup.sh

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -126,6 +126,25 @@ services:
          - elasticsearch.svc
     environment:
       discovery.type: single-node
+  quickstatements:
+    image: wikibase/quickstatements:latest
+    build:
+      context: ./quickstatements/latest
+      dockerfile: Dockerfile
+    ports:
+     - "9191:80"
+    depends_on:
+    - wikibase
+    networks:
+      default:
+        aliases:
+         - quickstatements.svc
+    environment:
+      - OAUTH_CONSUMER_KEY=559fcf1da153c5ec4b2fbefa7c3c395b
+      - OAUTH_CONSUMER_SECRET=57cad33da0015dce1e94a597908e19848714a6af
+      - QS_PUBLIC_SCHEME_HOST_AND_PORT=http://localhost:9191
+      - WB_PUBLIC_SCHEME_HOST_AND_PORT=http://localhost:8181
+      - WIKIBASE_SCHEME_AND_HOST=http://wikibase.svc
 
 volumes:
   mediawiki-mysql-data:

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -148,7 +148,7 @@ services:
       - WB_PROPERTY_NAMESPACE=122
       - "WB_PROPERTY_PREFIX=Property:"
       - WB_ITEM_NAMESPACE=120
-      - "WB_ITEcM_PREFIX=Item:"
+      - "WB_ITEM_PREFIX=Item:"
 
 volumes:
   mediawiki-mysql-data:

--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -145,6 +145,10 @@ services:
       - QS_PUBLIC_SCHEME_HOST_AND_PORT=http://localhost:9191
       - WB_PUBLIC_SCHEME_HOST_AND_PORT=http://localhost:8181
       - WIKIBASE_SCHEME_AND_HOST=http://wikibase.svc
+      - WB_PROPERTY_NAMESPACE=122
+      - "WB_PROPERTY_PREFIX=Property:"
+      - WB_ITEM_NAMESPACE=120
+      - "WB_ITEcM_PREFIX=Item:"
 
 volumes:
   mediawiki-mysql-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,6 +111,22 @@ services:
          - elasticsearch.svc
     environment:
       discovery.type: single-node
+  quickstatements:
+    image: wikibase/quickstatements:latest
+    ports:
+     - "9191:80"
+    depends_on:
+    - wikibase
+    networks:
+      default:
+        aliases:
+         - quickstatements.svc
+    environment:
+      - OAUTH_CONSUMER_KEY=559fcf1da153c5ec4b2fbefa7c3c395b
+      - OAUTH_CONSUMER_SECRET=57cad33da0015dce1e94a597908e19848714a6af
+      - QS_PUBLIC_SCHEME_HOST_AND_PORT=http://localhost:9191
+      - WB_PUBLIC_SCHEME_HOST_AND_PORT=http://localhost:8181
+      - WIKIBASE_SCHEME_AND_HOST=http://wikibase.svc
 
 volumes:
   mediawiki-mysql-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,6 +127,10 @@ services:
       - QS_PUBLIC_SCHEME_HOST_AND_PORT=http://localhost:9191
       - WB_PUBLIC_SCHEME_HOST_AND_PORT=http://localhost:8181
       - WIKIBASE_SCHEME_AND_HOST=http://wikibase.svc
+      - WB_PROPERTY_NAMESPACE=122
+      - "WB_PROPERTY_PREFIX=Property:"
+      - WB_ITEM_NAMESPACE=120
+      - "WB_ITEM_PREFIX=Item:"
 
 volumes:
   mediawiki-mysql-data:

--- a/quickstatements/README.md
+++ b/quickstatements/README.md
@@ -1,0 +1,104 @@
+# Quickstatements docker image
+
+Quickstatements2 as seen at  [https://tools.wmflabs.org/quickstatements/](https://tools.wmflabs.org/quickstatements/)
+
+### Tags
+Image name                            | Parent image                                    | Quickstatements version
+-------------------------------       | ------------------------                        | --------------        
+`wikibase/quickstatements` : `latest` | [php:5.6-apache](https://hub.docker.com/_/php/) | master                
+
+### Environment variables
+
+Variable                   | Default  | Description                                            
+-------------------------- | -------- | -----------                                            
+`WIKIBASE_HOST`            | NONE     | Host of wikibase instance as seen by QS container      
+`WB_PUBLIC_HOST_AND_PORT`  | NONE     | Host and port of wikibase as seen by the user's browser
+`QS_PUBLIC_HOST_AND_PORT`  | NONE     | Host and port of QS as seen by the user's browser      
+`OAUTH_CONSUMER_KEY`       | NONE     | OAuth consumer key (obtained from wikibase)            
+`OAUTH_CONSUMER_SECRET`    | NONE     | OAuth consumer key (obtained from wikibase)            
+`PHP_TIMEZONE`             | UTC      | setting of php.ini date.timezone                       
+
+### Filesystem layout
+
+Directory                                   | Description                                                                   
+---------------------------------           | ------------------------------------------------------------------------------
+`/var/www/html/quickstatements`             | Base quickstatements directory                                                
+`/var/www/html/quickstatements/public_html` | The Apache Root folder                                                        
+`/var/www/html/magnustools`                 | Base magnustools directory                                                    
+
+File                      | Description                                                                                                                              
+------------------------- | ------------------------------------------------------------------------------                                                           
+`/templates/config.json`  | Template for Quickstatements' config.json (substituted to `/var/www/html/quickstatements/public_html/config.json` at runtime)            
+`/templates/oauth.ini`    | Template for Quickstatements' oauth.ini (substituted to `/var/www/html/quickstatements/oauth.ini` at runtime)                            
+`/templates/php.ini`      | php config (default provided sets date.timezone to prevent php complaining substituted to `/usr/local/etc/php/conf.d/php.ini` at runtime)
+
+
+### How to setup and use
+
+#### Make a consumer on wikibase
+To make a consumer you will need an account that has an email address
+If you're using the wikibase/wikibase docker image and haven't set up email then
+use the maintenance script resetUserEmail.php and don't forget --no-reset-password
+
+Now log in as the admin user
+
+Now navigate to http://\<your wikibase\>/Special:OAuthConsumerRegistration
+
+Select request a token for a new consumer
+
+Register a consumer by filling in the form:
+1. Application name (e.g. 'Quickstatements)
+2. Version (you can leave this as 1.0)
+3. Description (e.g. 'Quickstatements')
+4. callback URL:  http://<your quickstatements host>/api.php
+5. Check "Allow consumer to specify a callback in requests"
+6. Request permission for:
+    * High-volume editing
+    * Edit existing pages
+    * Create, edit, and move pages
+7. Check agree and click "propose consumer"
+
+
+Make a note of the details on the following page
+
+#### Set up quickstatements
+In order for quickstatements to communicate with wikibase it needs to know where your instance is and how it can find it.
+This must be done by setting the ENV variable WIKIBASE_HOST. n.b. This should reflect how this container when running
+sees the wikibase container. For example the docker container alias like wikibase.svc.
+
+The user's browser will also be redirected to the Wikibase instance and finally back to quickstatements. The address
+the user sees for the Wikibase may be different from how the running container sees it. For example: it may be running
+on localhost on a specific port. e.g. http://localhost:8181. This should be passed to the quickstatements container as
+WB_PUBLIC_HOST_AND_PORT
+
+One must also know how this container will be visible to the user as well so it can ask the wikibase to redirect the
+user back here. This should be passed as QS_PUBLIC_HOST_AND_PORT
+
+You need to pass the consumer and secret token you got from the wikibase to this container as the environment variables
+ OAUTH_CONSUMER_KEY and OAUTH_CONSUMER_SECRET
+
+You can now test it works by navigating to http://\<your quickstatements host\> and logging in using the button top right.
+
+You should be redirected to the wiki where you can authorize this Quickstatements to act on your behalf
+
+Finally you should be redirected back to Quickstatements and you should appear logged in.
+
+Use Quickstatements as normal with the Run button. Currently "Run in background" is not supported by this image.
+
+#### Approve the consumer for other users
+So other users can also use quickstatements you also need to approve it as a consumer.
+
+Navigate to http://\<your wikibase\>/wiki/Special:OAuthManageConsumers/proposed
+
+Click 'review/manage' on your new consumer
+
+Then fill in any reason to approve the consumer (e.g. made by admin)
+
+and click 'Update consumer status'
+
+#### Troubleshooting
+If you see an error such as mw-oauth exception when trying to log in check that you have passed the right consumer token
+and secret token to quickstatements.
+
+If you have changed the value of $wgSecretKey $wgOAuthSecretKey since you made the consumer you'll need to make another new consumer or
+reissue the secret token for the old one.

--- a/quickstatements/README.md
+++ b/quickstatements/README.md
@@ -88,7 +88,7 @@ Use Quickstatements as normal with the Run button. Currently "Run in background"
 #### Approve the consumer for other users
 So other users can also use quickstatements you also need to approve it as a consumer.
 
-Navigate to http://\<your wikibase\>/wiki/Special:OAuthManageConsumers/proposed
+Navigate to http://\<your wikibase\>/Special:OAuthManageConsumers/proposed
 
 Click 'review/manage' on your new consumer
 

--- a/quickstatements/latest/.travis/build-deploy.sh
+++ b/quickstatements/latest/.travis/build-deploy.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+#Oneline for full directory name see: https://stackoverflow.com/questions/59895/getting-the-source-directory-of-a-bash-script-from-within
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+set -e
+docker build --pull "$DIR/../" -t wikibase/quickstatements:latest
+
+if [ "$SHOULD_DOCKER_PUSH" = true ]; then
+    docker push wikibase/quickstatements:latest
+fi

--- a/quickstatements/latest/Dockerfile
+++ b/quickstatements/latest/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu as fetcher
 
 RUN apt-get update && \
-    apt-get install --yes --no-install-recommends git ca-certificates
+    apt-get install --yes --no-install-recommends git=2.11.3-r0 ca-certificates=20170717~16.04.1
 
 RUN git clone --depth 1 https://phabricator.wikimedia.org/source/tool-quickstatements.git quickstatements
 RUN git clone --depth 1 https://bitbucket.org/magnusmanske/magnustools.git magnustools
@@ -13,13 +13,14 @@ FROM composer as composer
 
 COPY --from=fetcher /quickstatements /quickstatements
 
-RUN cd /quickstatements && composer install --no-dev
+WORKDIR /quickstatements
+RUN composer install --no-dev
 
 FROM php:5.6-apache
 
 # Install envsubst
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends gettext-base && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends gettext-base=0.19.8.1-r1 && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=composer /quickstatements /var/www/html/quickstatements
@@ -32,8 +33,8 @@ COPY oauth.ini /templates/oauth.ini
 COPY php.ini /templates/php.ini
 
 ENV APACHE_DOCUMENT_ROOT /var/www/html/quickstatements/public_html
-RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf
-RUN sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
+RUN sed -ri -e "'s!/var/www/html!${APACHE_DOCUMENT_ROOT}!g'" /etc/apache2/sites-available/*.conf
+RUN sed -ri -e "'s!/var/www/!${APACHE_DOCUMENT_ROOT}!g'" /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
 
 ENV MW_SITE_NAME=wikibase-docker\
     MW_SITE_LANG=en\

--- a/quickstatements/latest/Dockerfile
+++ b/quickstatements/latest/Dockerfile
@@ -1,7 +1,7 @@
-FROM ubuntu as fetcher
+FROM ubuntu:xenial as fetcher
 
 RUN apt-get update && \
-    apt-get install --yes --no-install-recommends git=2.11.3-r0 ca-certificates=20170717~16.04.1
+    apt-get install --yes --no-install-recommends git=1:2.7.4-0ubuntu1.3 ca-certificates=20170717~16.04.1
 
 RUN git clone --depth 1 https://phabricator.wikimedia.org/source/tool-quickstatements.git quickstatements
 RUN git clone --depth 1 https://bitbucket.org/magnusmanske/magnustools.git magnustools
@@ -20,7 +20,7 @@ FROM php:5.6-apache
 
 # Install envsubst
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends gettext-base=0.19.8.1-r1 && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends gettext-base=0.19.8.1-2 && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=composer /quickstatements /var/www/html/quickstatements
@@ -33,8 +33,8 @@ COPY oauth.ini /templates/oauth.ini
 COPY php.ini /templates/php.ini
 
 ENV APACHE_DOCUMENT_ROOT /var/www/html/quickstatements/public_html
-RUN sed -ri -e "'s!/var/www/html!${APACHE_DOCUMENT_ROOT}!g'" /etc/apache2/sites-available/*.conf
-RUN sed -ri -e "'s!/var/www/!${APACHE_DOCUMENT_ROOT}!g'" /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
+RUN sed -ri -e "s!/var/www/html!${APACHE_DOCUMENT_ROOT}!g" /etc/apache2/sites-available/*.conf
+RUN sed -ri -e "s!/var/www/!${APACHE_DOCUMENT_ROOT}!g" /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
 
 ENV MW_SITE_NAME=wikibase-docker\
     MW_SITE_LANG=en\

--- a/quickstatements/latest/Dockerfile
+++ b/quickstatements/latest/Dockerfile
@@ -1,0 +1,45 @@
+FROM ubuntu as fetcher
+
+RUN apt-get update && \
+    apt-get install --yes --no-install-recommends git ca-certificates
+
+RUN git clone --depth 1 https://phabricator.wikimedia.org/source/tool-quickstatements.git quickstatements
+RUN git clone --depth 1 https://bitbucket.org/magnusmanske/magnustools.git magnustools
+
+RUN rm -rf quickstatements/.git
+RUN rm -rf magnustools/.git
+
+FROM composer as composer
+
+COPY --from=fetcher /quickstatements /quickstatements
+
+RUN cd /quickstatements && composer install --no-dev
+
+FROM php:5.6-apache
+
+# Install envsubst
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends gettext-base && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=composer /quickstatements /var/www/html/quickstatements
+COPY --from=fetcher /magnustools /var/www/html/magnustools
+
+COPY entrypoint.sh /entrypoint.sh
+
+COPY config.json /templates/config.json
+COPY oauth.ini /templates/oauth.ini
+COPY php.ini /templates/php.ini
+
+ENV APACHE_DOCUMENT_ROOT /var/www/html/quickstatements/public_html
+RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf
+RUN sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
+
+ENV MW_SITE_NAME=wikibase-docker\
+    MW_SITE_LANG=en\
+    PHP_TIMEZONE=UTC
+
+RUN install -d -owww-data /var/log/quickstatements
+
+ENTRYPOINT ["/bin/bash"]
+CMD ["/entrypoint.sh"]

--- a/quickstatements/latest/config.json
+++ b/quickstatements/latest/config.json
@@ -17,8 +17,8 @@
 			"pageBase" : "${WB_PUBLIC_SCHEME_HOST_AND_PORT}/wiki/" ,
 			"toolBase" : "${QS_PUBLIC_SCHEME_HOST_AND_PORT}/" ,
 			"types" : {
-				"P" : { "type":"property" , "ns":122 , "ns_prefix":"Property:" } ,
-				"Q" : { "type":"item" , "ns":120 , "ns_prefix":"Item:" }
+				"P" : { "type":"property" , "ns":"${WB_PROPERTY_NAMESPACE}" , "ns_prefix":"${WB_PROPERTY_PREFIX}" } ,
+				"Q" : { "type":"item" , "ns":"${WB_ITEM_NAMESPACE}" , "ns_prefix":"${WB_ITEM_PREFIX}" }
 			}
 		}
 	}

--- a/quickstatements/latest/config.json
+++ b/quickstatements/latest/config.json
@@ -1,0 +1,25 @@
+{
+	"site" : "${MW_SITE_NAME}" ,
+	"bot_config_file" : "/var/www/html/bot.ini" ,
+	"logfile" : "/var/log/quickstatements/tool.log" ,
+	"sites" : {
+		"${MW_SITE_NAME}" : {
+			"oauth" : {
+				"language":"${MW_SITE_LANG}" ,
+				"project":"${MW_SITE_NAME}" ,
+				"ini_file":"/var/www/html/quickstatements/oauth.ini" ,
+				"publicMwOAuthUrl":"${WB_PUBLIC_SCHEME_HOST_AND_PORT}/w/index.php?title=Special:OAuth" ,
+				"mwOAuthUrl":"${WIKIBASE_SCHEME_AND_HOST}/w/index.php?title=Special:OAuth" ,
+				"mwOAuthIW":"mw"
+			} ,
+			"server" : "${WB_PUBLIC_HOST_AND_PORT}" ,
+			"api" : "${WIKIBASE_SCHEME_AND_HOST}/w/api.php" ,
+			"pageBase" : "${WB_PUBLIC_SCHEME_HOST_AND_PORT}/wiki/" ,
+			"toolBase" : "${QS_PUBLIC_SCHEME_HOST_AND_PORT}/" ,
+			"types" : {
+				"P" : { "type":"property" , "ns":122 , "ns_prefix":"Property:" } ,
+				"Q" : { "type":"item" , "ns":120 , "ns_prefix":"Item:" }
+			}
+		}
+	}
+}

--- a/quickstatements/latest/entrypoint.sh
+++ b/quickstatements/latest/entrypoint.sh
@@ -9,7 +9,6 @@ for i in ${REQUIRED_VARIABLES[@]}; do
     fi
 done
 
-export DOLLAR='$'
 envsubst < /templates/config.json > /var/www/html/quickstatements/public_html/config.json
 envsubst < /templates/oauth.ini > /var/www/html/quickstatements/oauth.ini
 envsubst < /templates/php.ini > /usr/local/etc/php/conf.d/php.ini

--- a/quickstatements/latest/entrypoint.sh
+++ b/quickstatements/latest/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Test if required environment variables have been set
-REQUIRED_VARIABLES=(OAUTH_CONSUMER_KEY OAUTH_CONSUMER_SECRET QS_PUBLIC_SCHEME_HOST_AND_PORT WB_PUBLIC_SCHEME_HOST_AND_PORT WIKIBASE_SCHEME_AND_HOST)
+REQUIRED_VARIABLES=(OAUTH_CONSUMER_KEY OAUTH_CONSUMER_SECRET QS_PUBLIC_SCHEME_HOST_AND_PORT WB_PUBLIC_SCHEME_HOST_AND_PORT WIKIBASE_SCHEME_AND_HOST WB_PROPERTY_NAMESPACE WB_PROPERTY_PREFIX WB_ITEM_NAMESPACE WB_ITEM_PREFIX)
 for i in ${REQUIRED_VARIABLES[@]}; do
     if ! [[ -v "$i" ]]; then
     echo "$i is required but isn't set. You should pass it to docker. See: https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file";

--- a/quickstatements/latest/entrypoint.sh
+++ b/quickstatements/latest/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Test if required environment variables have been set
+REQUIRED_VARIABLES=(OAUTH_CONSUMER_KEY OAUTH_CONSUMER_SECRET QS_PUBLIC_SCHEME_HOST_AND_PORT WB_PUBLIC_SCHEME_HOST_AND_PORT WIKIBASE_SCHEME_AND_HOST)
+for i in ${REQUIRED_VARIABLES[@]}; do
+    if ! [[ -v "$i" ]]; then
+    echo "$i is required but isn't set. You should pass it to docker. See: https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file";
+    exit 1;
+    fi
+done
+
+export DOLLAR='$'
+envsubst < /templates/config.json > /var/www/html/quickstatements/public_html/config.json
+envsubst < /templates/oauth.ini > /var/www/html/quickstatements/oauth.ini
+envsubst < /templates/php.ini > /usr/local/etc/php/conf.d/php.ini
+
+docker-php-entrypoint apache2-foreground

--- a/quickstatements/latest/oauth.ini
+++ b/quickstatements/latest/oauth.ini
@@ -1,0 +1,5 @@
+; HTTP User-Agent header
+agent = 'Wikibase Docker QuickStatements'
+; assigned by Special:OAuthConsumerRegistration (request modelled after https://www.wikidata.org/wiki/Special:OAuthListConsumers/view/77b4ae5506dd7dbb0bb07f80e3ae3ca9)
+consumerKey = '${OAUTH_CONSUMER_KEY}'
+consumerSecret = '${OAUTH_CONSUMER_SECRET}'

--- a/quickstatements/latest/php.ini
+++ b/quickstatements/latest/php.ini
@@ -1,0 +1,1 @@
+date.timezone = "${PHP_TIMEZONE}"

--- a/wikibase/1.30/bundle/LocalSettings.php.wikibase-bundle.template
+++ b/wikibase/1.30/bundle/LocalSettings.php.wikibase-bundle.template
@@ -3,6 +3,7 @@ wfLoadExtension( 'OAuth' );
 ${DOLLAR}wgGroupPermissions['sysop']['mwoauthproposeconsumer'] = true;
 ${DOLLAR}wgGroupPermissions['sysop']['mwoauthmanageconsumer'] = true;
 ${DOLLAR}wgGroupPermissions['sysop']['mwoauthviewprivate'] = true;
+${DOLLAR}wgGroupPermissions['sysop']['mwoauthupdateownconsumer'] = true;
 
 # WikibaseImport
 require_once "${DOLLAR}IP/extensions/WikibaseImport/WikibaseImport.php";


### PR DESCRIPTION
Create image from magnus's head from both Github and Bitbucket

Use compose to get QS dependencies

Use php container as base. Set up layout a little like toolforge to work with
magnus's code.

Documentation is quite involved (since there is currently no QS setup documentation to read)

Ugly-ist bit is having to set the user email with a maint script because we don't have email in docker yet and OAuth *demands* an email to let you make a consumer.