### PR TITLE
Use deploy binaries from WMF Archiva

### DIFF
--- a/wdqs/0.2.5/Dockerfile
+++ b/wdqs/0.2.5/Dockerfile
@@ -3,9 +3,8 @@ FROM ubuntu as fetcher
 RUN apt-get update && \
     apt-get install --yes --no-install-recommends unzip
 
-ADD https://search.maven.org/remotecontent?filepath=org/wikidata/query/rdf/service/0.2.5/service-0.2.5-dist.zip ./service-dist.zip
+ADD https://archiva.wikimedia.org/repository/snapshots/org/wikidata/query/rdf/service/0.2.5-SNAPSHOT/service-0.2.5-SNAPSHOT-dist.zip ./service-dist.zip
 
-# Creates /wikidata-query-deploy
 RUN unzip service-dist.zip && rm service-dist.zip
 
 
@@ -16,7 +15,7 @@ FROM openjdk:8-jdk-alpine
 RUN set -x; \
     apk --update add bash gettext libintl
 
-COPY --from=fetcher /service-0.2.5 /wdqs
+COPY --from=fetcher /service-0.2.5-SNAPSHOT /wdqs
 
 # Don't set a memory limit otherwise bad things happen (OOMs)
 ENV MEMORY=""\

--- a/wdqs/0.3.0/Dockerfile
+++ b/wdqs/0.3.0/Dockerfile
@@ -3,9 +3,8 @@ FROM ubuntu as fetcher
 RUN apt-get update && \
     apt-get install --yes --no-install-recommends unzip
 
-ADD https://search.maven.org/remotecontent?filepath=org/wikidata/query/rdf/service/0.3.0/service-0.3.0-dist.zip ./service-dist.zip
+ADD https://archiva.wikimedia.org/repository/snapshots/org/wikidata/query/rdf/service/0.3.0-SNAPSHOT/service-0.3.0-SNAPSHOT-dist.zip ./service-dist.zip
 
-# Creates /wikidata-query-deploy
 RUN unzip service-dist.zip && rm service-dist.zip
 
 
@@ -16,7 +15,7 @@ FROM openjdk:8-jdk-alpine
 RUN set -x; \
     apk --update add bash gettext libintl
 
-COPY --from=fetcher /service-0.3.0 /wdqs
+COPY --from=fetcher /service-0.3.0-SNAPSHOT /wdqs
 
 # Don't set a memory limit otherwise bad things happen (OOMs)
 ENV MEMORY=""\


### PR DESCRIPTION
This has two benefits:
1. we stop relying on maven's infrastructure
2. we get the latest deploy binaries which are newer than the releases
