### PR TITLE
Accept a range of versions for apt and apk packages

### DIFF
--- a/wdqs-frontend/latest/Dockerfile
+++ b/wdqs-frontend/latest/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:xenial as fetcher
 
 RUN apt-get update && \
-    apt-get install --yes --no-install-recommends unzip=6.0-20ubuntu1
+    apt-get install --yes --no-install-recommends unzip=6.*
 
 ADD https://github.com/wikimedia/wikidata-query-gui/archive/master.zip ./master.zip
 
@@ -17,7 +17,7 @@ WORKDIR /tmp/wikidata-query-gui-master
 
 # Put wdqs gui in the right place
 RUN set -x ; \
-    apk --no-cache add --virtual build-dependencies ca-certificates=20171114-r0 git=2.15.2-r0 nodejs=8.9.3-r1 jq=1.5-r5 \
+    apk --no-cache add --virtual build-dependencies ca-certificates~=20171114-r0 git~=2.15.2-r0 nodejs~=8.9.3-r1 jq~=1.5-r5 \
     && mv package.json package.json.orig \
     && jq 'delpaths([["devDependencies","karma-qunit"],["devDependencies","qunitjs"],["devDependencies","sinon"]])' \
         > package.json < package.json.orig \

--- a/wdqs/0.2.5/Dockerfile
+++ b/wdqs/0.2.5/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:xenial as fetcher
 
 RUN apt-get update && \
-    apt-get install --yes --no-install-recommends unzip=6.0-20ubuntu1
+    apt-get install --yes --no-install-recommends unzip=6.*
 
 ADD https://archiva.wikimedia.org/repository/snapshots/org/wikidata/query/rdf/service/0.2.5-SNAPSHOT/service-0.2.5-SNAPSHOT-dist.zip ./service-dist.zip
 
@@ -13,7 +13,7 @@ FROM openjdk:8-jdk-alpine
 # Blazegraph scripts require bash
 # Install gettext for envsubst command, (it needs libintl package)
 RUN set -x ; \
-    apk --no-cache add bash=4.4.19-r1 gettext=0.19.8.1-r1 libintl=0.19.8.1-r1
+    apk --no-cache add bash~=4.4.19-r1 gettext~=0.19.8.1-r1 libintl~=0.19.8.1-r1
 
 COPY --from=fetcher /service-0.2.5-SNAPSHOT /wdqs
 

--- a/wdqs/0.3.0/Dockerfile
+++ b/wdqs/0.3.0/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:xenial as fetcher
 
 RUN apt-get update && \
-    apt-get install --yes --no-install-recommends unzip=6.0-20ubuntu1
+    apt-get install --yes --no-install-recommends unzip=6.*
 
 ADD https://archiva.wikimedia.org/repository/snapshots/org/wikidata/query/rdf/service/0.3.0-SNAPSHOT/service-0.3.0-SNAPSHOT-dist.zip ./service-dist.zip
 
@@ -13,7 +13,7 @@ FROM openjdk:8-jdk-alpine
 # Blazegraph scripts require bash
 # Install gettext for envsubst command, (it needs libintl package)
 RUN set -x ; \
-    apk --no-cache add bash=4.4.19-r1 gettext=0.19.8.1-r1 libintl=0.19.8.1-r1
+    apk --no-cache add bash~=4.4.19-r1 gettext~=0.19.8.1-r1 libintl~=0.19.8.1-r1
 
 COPY --from=fetcher /service-0.3.0-SNAPSHOT /wdqs
 

--- a/wikibase/1.29/Dockerfile
+++ b/wikibase/1.29/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:xenial as fetcher
 
 RUN apt-get update && \
-    apt-get install --yes --no-install-recommends unzip=6.0-20ubuntu1
+    apt-get install --yes --no-install-recommends unzip=6.*
 
 ADD https://github.com/wikimedia/mediawiki-extensions-Wikibase/archive/REL1_29.zip .
 
@@ -21,7 +21,7 @@ FROM mediawiki:1.29
 
 # Install envsubst
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends gettext-base=0.19.8.1-2 && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends gettext-base=0.19.* && \
     rm -rf /var/lib/apt/lists/*
 
 RUN a2enmod rewrite

--- a/wikibase/1.30/base/Dockerfile
+++ b/wikibase/1.30/base/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:xenial as fetcher
 
 RUN apt-get update && \
-    apt-get install --yes --no-install-recommends unzip=6.0-20ubuntu1
+    apt-get install --yes --no-install-recommends unzip=6.*
 
 ADD https://github.com/wikimedia/mediawiki-extensions-Wikibase/archive/REL1_30.zip .
 
@@ -21,7 +21,7 @@ FROM mediawiki:1.30
 
 # Install envsubst
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends gettext-base=0.19.8.1-2 && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends gettext-base=0.19.* && \
     rm -rf /var/lib/apt/lists/*
 
 RUN a2enmod rewrite

--- a/wikibase/1.30/bundle/Dockerfile
+++ b/wikibase/1.30/bundle/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:xenial as fetcher
 
 RUN apt-get update && \
-    apt-get install --yes --no-install-recommends unzip=6.0-20ubuntu1 jq=1.5+dfsg-1 curl=7.47.0-1ubuntu2.8 ca-certificates=20170717~16.04.1
+    apt-get install --yes --no-install-recommends unzip=6.* jq=1.* curl=7.* ca-certificates=201*
 COPY download-extension.sh .
 ADD https://github.com/filbertkm/WikibaseImport/archive/master.tar.gz /WikibaseImport.tar.gz
 RUN bash download-extension.sh OAuth;\


### PR DESCRIPTION
In case the versions are available are increased upstream and the
version we were exactly pinned to become unavailable it is nice to
accept a sensible range.

With apt we use a wildcard and avoid going up more than a major
version.

With apk we can use the built in semver syntax with '~'