### PR TITLE
Relax pinned versions in quickstatements Dockerfile

### DIFF
--- a/quickstatements/latest/Dockerfile
+++ b/quickstatements/latest/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:xenial as fetcher
 
 RUN apt-get update && \
-    apt-get install --yes --no-install-recommends git=1:2.7.4-0ubuntu1.3 ca-certificates=20170717~16.04.1
+    apt-get install --yes --no-install-recommends git=1:2.* ca-certificates=201*
 
 RUN git clone --depth 1 https://phabricator.wikimedia.org/source/tool-quickstatements.git quickstatements
 RUN git clone --depth 1 https://bitbucket.org/magnusmanske/magnustools.git magnustools
@@ -20,7 +20,7 @@ FROM php:5.6-apache
 
 # Install envsubst
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends gettext-base=0.19.8.1-2 && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends gettext-base=0.19.* && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=composer /quickstatements /var/www/html/quickstatements


### PR DESCRIPTION
Pinning exact versions means that the image fails to build if even the smallest update to the package, since the old version might no longer be available (for example, in Ubuntu Xenial the Git version recently changed from 1:2.7.4-0ubuntu1.3 to 1:2.7.4-0ubuntu1.**4**). Instead, relax the version requirements using globs, as done in other Dockerfiles.