### PR TITLE
Travis CI pin hadolint versoin

### DIFF
--- a/.travis/run-linters.sh
+++ b/.travis/run-linters.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-docker pull hadolint/hadolint
+docker pull hadolint/hadolint tag: v1.6.5
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 


### PR DESCRIPTION
Fix: Travis CI for wikibase-docker is blocked by hadolint Linting failure

https://phabricator.wikimedia.org/T201995