### PR TITLE
Add calendar to php

### DIFF
--- a/wikibase/1.29/Dockerfile
+++ b/wikibase/1.29/Dockerfile
@@ -29,6 +29,8 @@ RUN a2enmod rewrite
 
 RUN install -d /var/log/mediawiki -o www-data
 
+RUN docker-php-ext-install calendar
+
 COPY --from=composer /Wikibase /var/www/html/extensions/Wikibase
 COPY wait-for-it.sh /wait-for-it.sh
 COPY entrypoint.sh /entrypoint.sh

--- a/wikibase/1.30/base/Dockerfile
+++ b/wikibase/1.30/base/Dockerfile
@@ -29,6 +29,8 @@ RUN a2enmod rewrite
 
 RUN install -d /var/log/mediawiki -o www-data
 
+RUN docker-php-ext-install calendar
+
 COPY --from=composer /Wikibase /var/www/html/extensions/Wikibase
 COPY wait-for-it.sh /wait-for-it.sh
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
Needed for the RDF dumper to work and not included in the
default php install provided by the mediawiki images.

Bug: T203528