### PR TITLE
Limit ES memory in default yml to 0.5GB

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,6 +119,7 @@ services:
          - elasticsearch.svc
     environment:
       discovery.type: single-node
+      ES_JAVA_OPTS: "-Xms512m -Xmx512m"
   # CONFING, in order to not load quickstatements then remove this entire section
   quickstatements:
     image: wikibase/quickstatements:latest


### PR DESCRIPTION
Up for debate if we want to keep pushing more into the default config since it is hard to guess users needs but this stops using what ever the default is from elastic.co