### PR TITLE
Add concepturi and wgserver to make cirrussearch work via https

### DIFF
--- a/wdqs/0.3.1/entrypoint.sh
+++ b/wdqs/0.3.1/entrypoint.sh
@@ -10,11 +10,12 @@ for i in ${REQUIRED_VARIABLES[@]}; do
     exit 1;
     fi
 done
-
+export WIKIBASE_SCHEME="${WIKIBASE_SCHEME:-http}"
+export WIKIBASE_CONCEPT_URI="${WIKIBASE_CONCEPT_URI:-${WIKIBASE_SCHEME}://${WIKIBASE_HOST}}"
 set -eu
 
-export BLAZEGRAPH_OPTS="-DwikibaseHost=${WIKIBASE_HOST}"
-export UPDATER_OPTS="-DwikibaseHost=${WIKIBASE_HOST} -DwikibaseMaxDaysBack=${WIKIBASE_MAX_DAYS_BACK}"
+export BLAZEGRAPH_OPTS="-DwikibaseHost=${WIKIBASE_HOST} -DwikibaseScheme=${WIKIBASE_SCHEME} -DwikibaseConceptUri=${WIKIBASE_CONCEPT_URI}"
+export UPDATER_OPTS="-DwikibaseHost=${WIKIBASE_HOST} -DwikibaseScheme=${WIKIBASE_SCHEME} -DwikibaseMaxDaysBack=${WIKIBASE_MAX_DAYS_BACK}"
 
 envsubst < /templates/mwservices.json > /wdqs/mwservices.json
 

--- a/wdqs/0.3.1/runUpdate.sh
+++ b/wdqs/0.3.1/runUpdate.sh
@@ -6,4 +6,6 @@ cd /wdqs
 # TODO env vars for entity namespaces, scheme and other settings
 /wait-for-it.sh $WIKIBASE_HOST:80 -t 120 -- \
 /wait-for-it.sh $WDQS_HOST:$WDQS_PORT -t 120 -- \
-./runUpdate.sh -h http://$WDQS_HOST:$WDQS_PORT -- --wikibaseHost $WIKIBASE_HOST --wikibaseScheme $WIKIBASE_SCHEME --entityNamespaces $WDQS_ENTITY_NAMESPACES
+export WIKIBASE_SCHEME="${WIKIBASE_SCHEME:-http}"
+export WIKIBASE_CONCEPT_URI="${WIKIBASE_CONCEPT_URI:-${WIKIBASE_SCHEME}://${WIKIBASE_HOST}}"
+./runUpdate.sh -h http://$WDQS_HOST:$WDQS_PORT -- --wikibaseHost $WIKIBASE_HOST --wikibaseScheme $WIKIBASE_SCHEME --entityNamespaces $WDQS_ENTITY_NAMESPACES --conceptUri $WIKIBASE_CONCEPT_URI

--- a/wdqs/README.md
+++ b/wdqs/README.md
@@ -27,16 +27,17 @@ If you can not use RecentChanges then you will need to reload from an RDF dump:
 
 ### Environment variables
 
-Variable                 | Default            | Since   | Description
--------------------------|  ------------------| --------| ----------
-`MEMORY`                 | ""                 | 0.2.5   | Memory limit for blazegraph
-`HEAP_SIZE`              | "1g"               | 0.2.5   | Heap size for blazegraph
-`WIKIBASE_HOST`          | "wikibase.svc"     | 0.2.5   | Hostname of the Wikibase host
-`WIKIBASE_SCHEME`        | "http"             | 0.2.5   | Scheme of the Wikibase host
-`WDQS_HOST`              | "wdqs.svc"         | 0.2.5   | Hostname of the WDQS host (this service)
-`WDQS_PORT`              | "9999"             | 0.2.5   | Port of the WDQS host (this service)
-`WDQS_ENTITY_NAMESPACES` | "120,122"          | 0.2.5   | Wikibase Namespaces to load data from
-`WIKIBASE_MAX_DAYS_BACK` | "90"               | 0.3.0   | Max days updater is allowed back from now
+Variable                 | Default               | Since   | Description
+-------------------------|  ---------------------| --------| ----------
+`MEMORY`                 | ""                    | 0.2.5   | Memory limit for blazegraph
+`HEAP_SIZE`              | "1g"                  | 0.2.5   | Heap size for blazegraph
+`WIKIBASE_HOST`          | "wikibase.svc"        | 0.2.5   | Hostname of the Wikibase host
+`WIKIBASE_SCHEME`        | "http"                | 0.2.5   | Scheme of the Wikibase host
+`WDQS_HOST`              | "wdqs.svc"            | 0.2.5   | Hostname of the WDQS host (this service)
+`WDQS_PORT`              | "9999"                | 0.2.5   | Port of the WDQS host (this service)
+`WDQS_ENTITY_NAMESPACES` | "120,122"             | 0.2.5   | Wikibase Namespaces to load data from
+`WIKIBASE_MAX_DAYS_BACK` | "90"                  | 0.3.0   | Max days updater is allowed back from now
+`WIKIBASE_CONCEPT_URI`   | "http://wikibase.svc" | 0.3.1   | URL base of the URLs used to represent Wikibase entities in RDF. E.g. http://www.wikidata.org. Must be set if the Wikibase instance does not use Wikidata-based prefixes.
 
 
 ### Filesystem layout

--- a/wikibase/1.32/base/Dockerfile
+++ b/wikibase/1.32/base/Dockerfile
@@ -39,7 +39,8 @@ COPY htaccess /var/www/html/.htaccess
 RUN ln -s /var/www/html/ /var/www/html/w
 
 ENV MW_SITE_NAME=wikibase-docker\
-    MW_SITE_LANG=en
+    MW_SITE_LANG=en\
+    MW_SERVER=http://localhost:8181
 
 ENTRYPOINT ["/bin/bash"]
 CMD ["/entrypoint.sh"]

--- a/wikibase/1.32/base/LocalSettings.php.template
+++ b/wikibase/1.32/base/LocalSettings.php.template
@@ -28,6 +28,7 @@ ${DOLLAR}wgDebugLogGroups = array(
 ${DOLLAR}wgShellLocale = "en_US.utf8";
 ${DOLLAR}wgLanguageCode = "${MW_SITE_LANG}";
 ${DOLLAR}wgSitename = "${MW_SITE_NAME}";
+${DOLLAR}wgServer = "${MW_SERVER}";
 ${DOLLAR}wgMetaNamespace = "Project";
 # Configured web paths & short URLs
 # This allows use of the /wiki/* path

--- a/wikibase/1.32/base/entrypoint.sh
+++ b/wikibase/1.32/base/entrypoint.sh
@@ -2,7 +2,7 @@
 # This file is provided by the wikibase/wikibase docker image.
 
 # Test if required environment variables have been set
-REQUIRED_VARIABLES=(MW_ADMIN_NAME MW_ADMIN_PASS MW_ADMIN_EMAIL MW_WG_SECRET_KEY DB_SERVER DB_USER DB_PASS DB_NAME)
+REQUIRED_VARIABLES=(MW_ADMIN_NAME MW_ADMIN_PASS MW_ADMIN_EMAIL MW_WG_SECRET_KEY DB_SERVER DB_USER DB_PASS DB_NAME MW_SERVER)
 for i in ${REQUIRED_VARIABLES[@]}; do
     eval THISSHOULDBESET=\$$i
     if [ -z "$THISSHOULDBESET" ]; then

--- a/wikibase/README.md
+++ b/wikibase/README.md
@@ -44,17 +44,18 @@ A blog post documenting the update progress for this image in a docker-compose s
 
 Note: MW_ADMIN_NAME and MW_ADMIN_PASS probably shouldn't be here...
 
-Variable          | Default              | Description
-------------------|  --------------------| ----------
-`DB_SERVER`       | "mysql.svc:3306"     | Hostname and port for the MySQL server to use for Mediawiki & Wikibase
-`DB_USER`         | "wikiuser"           | Username to use for the MySQL server
-`DB_PASS`         | "sqlpass"            | Password to use for the MySQL server
-`DB_NAME`         | "my_wiki"            | Database name to use for the MySQL server
-`MW_SITE_NAME`    | "wikibase-docker"    | $wgSitename to use for MediaWiki
-`MW_SITE_LANG`    | "en"                 | $wgLanguageCode to use for MediaWiki
-`MW_ADMIN_NAME`   | "admin"              | Admin username to create on MediaWiki first install
-`MW_ADMIN_PASS`   | "adminpass"          | Admin password to use for admin account on first install
-`MW_WG_SECRET_KEY`| "secretkey"          | Used as source of entropy for persistent login/Oauth etc..(since 1.30)
+Variable          | Default                 | Description
+------------------|  -----------------------| ----------
+`DB_SERVER`       | "mysql.svc:3306"        | Hostname and port for the MySQL server to use for Mediawiki & Wikibase
+`DB_USER`         | "wikiuser"              | Username to use for the MySQL server
+`DB_PASS`         | "sqlpass"               | Password to use for the MySQL server
+`DB_NAME`         | "my_wiki"               | Database name to use for the MySQL server
+`MW_SERVER`       | "http://localhost:8181" | $wgServer to use for MediaWiki
+`MW_SITE_NAME`    | "wikibase-docker"       | $wgSitename to use for MediaWiki
+`MW_SITE_LANG`    | "en"                    | $wgLanguageCode to use for MediaWiki
+`MW_ADMIN_NAME`   | "admin"                 | Admin username to create on MediaWiki first install
+`MW_ADMIN_PASS`   | "adminpass"             | Admin password to use for admin account on first install
+`MW_WG_SECRET_KEY`| "secretkey"             | Used as source of entropy for persistent login/Oauth etc..(since 1.30)
 
 ### Filesystem layout
 


### PR DESCRIPTION
We run wikibase in kubernetes, and found it necessary to make these modifications to have all of the following:
1. our wikibase be served with https
2. use [http for Wikibase concept URI for RDF entities](https://www.mediawiki.org/wiki/Wikidata_Query_Service/Implementation/Standalone#Setting_concept_URI)
3. still have CirrusSearch work without mixed content errors.

Because we are using kubernetes and not docker compose/swarm, we have not extensively tested the changes in what is probably your more default environment.