### PR TITLE
chore: set restart=on-failure on wikibase

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
     depends_on:
     - mysql
     - elasticsearch
+    restart: on-failure
     networks:
       default:
         aliases:


### PR DESCRIPTION
Sometimes, `wikibase` fails because its dependencies are not yet ready.

A manual `docker-compose up -d` is then required.

Using the proposed [restart_policy](https://docs.docker.com/compose/compose-file/#restart) should make the whole experience smoother while allowing to manually exit the main process.