### PR TITLE
Install Python in wdqs-frontend builder

### DIFF
--- a/wdqs-frontend/latest/Dockerfile
+++ b/wdqs-frontend/latest/Dockerfile
@@ -18,7 +18,7 @@ COPY --from=fetcher /wikidata-query-gui-master /tmp/wikidata-query-gui-master
 WORKDIR /tmp/wikidata-query-gui-master
 
 # Put wdqs gui in the right place
-RUN apk --no-cache add --virtual build-dependencies ca-certificates~=20190108 git~=2.20 nodejs~=10 npm~=10 jq~=1.6
+RUN apk --no-cache add --virtual build-dependencies ca-certificates~=20190108 git~=2.20 nodejs~=10 npm~=10 jq~=1.6 python~=2.7 make~=4.2 g++~=8.2
 
 # TODO do npm build instead of leaving any dev node modules hanging around
 RUN mv package.json package.json.orig \


### PR DESCRIPTION
One of the packages required by wdio-mocha-framework, which the WDQS frontend uses since [Iad6b8a28d6][1], requires Python to be installed.

[1]: https://gerrit.wikimedia.org/r/499491

---

Fallout from #38.