### PR TITLE
Only generate OAuth data for QuickStatements if the file does not exist

### DIFF
--- a/wikibase/1.32/bundle/extra-install.sh
+++ b/wikibase/1.32/bundle/extra-install.sh
@@ -4,6 +4,8 @@ php /var/www/html/extensions/CirrusSearch/maintenance/updateSearchIndexConfig.ph
 php /var/www/html/extensions/CirrusSearch/maintenance/forceSearchIndex.php --skipParse
 php /var/www/html/extensions/CirrusSearch/maintenance/forceSearchIndex.php --skipLinks --indexOnSkip
 
-php /var/www/html/extensions/OAuth/maintenance/createOAuthConsumer.php --approve --callbackUrl  $QS_PUBLIC_SCHEME_HOST_AND_PORT \
-	--callbackIsPrefix true --user Admin --name QuickStatements --description QuickStatements --version 1.0.1 \
-	--grants createeditmovepage --grants editpage --grants highvolume --jsonOnSuccess > /quickstatements/data/qs-oauth.json
+if [ ! -e "/quickstatements/data/qs-oauth.json" ]; then
+	php /var/www/html/extensions/OAuth/maintenance/createOAuthConsumer.php --approve --callbackUrl  $QS_PUBLIC_SCHEME_HOST_AND_PORT \
+		--callbackIsPrefix true --user Admin --name QuickStatements --description QuickStatements --version 1.0.1 \
+		--grants createeditmovepage --grants editpage --grants highvolume --jsonOnSuccess > /quickstatements/data/qs-oauth.json
+fi


### PR DESCRIPTION
Somehow file gets overwritten with an empty file sometimes.
This might, or might not, prevent this.