### PR TITLE
 custom-config.json is now replacing the default-config.json

### DIFF
--- a/wdqs-frontend/latest/entrypoint.sh
+++ b/wdqs-frontend/latest/entrypoint.sh
@@ -15,7 +15,7 @@ fi
 set -eu
 
 export DOLLAR='$'
-envsubst < /templates/custom-config.json > /usr/share/nginx/html/wikibase/custom-config.json
+envsubst < /templates/custom-config.json > /usr/share/nginx/html/default-config.json
 envsubst < /templates/default.conf > /etc/nginx/conf.d/default.conf
 
 exec "$@"

--- a/wdqs-frontend/latest/entrypoint.sh
+++ b/wdqs-frontend/latest/entrypoint.sh
@@ -15,7 +15,7 @@ fi
 set -eu
 
 export DOLLAR='$'
-envsubst < /templates/custom-config.json > /usr/share/nginx/html/default-config.json
+envsubst < /templates/custom-config.json > /usr/share/nginx/html/custom-config.json
 envsubst < /templates/default.conf > /etc/nginx/conf.d/default.conf
 
 exec "$@"


### PR DESCRIPTION
The custom-config.json is now replacing the default-config.json. The default-config.json was still used when running a private docker base and this caused the local query interface to query wikidata instead of the local instance.

There might be a better solution in which it automatically detects the template but I am not aware of such method.