### PR TITLE
Clean uncompressed tar files in 1.31 and 1.32 wikibase bundles

### DIFF
--- a/wikibase/1.31/bundle/Dockerfile
+++ b/wikibase/1.31/bundle/Dockerfile
@@ -16,7 +16,8 @@ tar xzf Elastica.tar.gz;\
 tar xzf CirrusSearch.tar.gz;\
 tar xzf UniversalLanguageSelector.tar.gz;\
 tar xzf cldr.tar.gz;\
-tar xzf WikibaseImport.tar.gz
+tar xzf WikibaseImport.tar.gz;\
+rm ./*.tar.gz
 
 FROM composer as composer
 COPY --from=fetcher /WikibaseImport-master /WikibaseImport

--- a/wikibase/1.32/bundle/Dockerfile
+++ b/wikibase/1.32/bundle/Dockerfile
@@ -16,7 +16,8 @@ tar xzf Elastica.tar.gz;\
 tar xzf CirrusSearch.tar.gz;\
 tar xzf UniversalLanguageSelector.tar.gz;\
 tar xzf cldr.tar.gz;\
-tar xzf WikibaseImport.tar.gz
+tar xzf WikibaseImport.tar.gz;\
+rm ./*.tar.gz
 
 FROM composer as composer
 COPY --from=fetcher /WikibaseImport-master /WikibaseImport


### PR DESCRIPTION
This would drop 30MB from large ~270MB images