### PR TITLE
Updated git version used in the intermediate container when building WDQS UI image

### DIFF
--- a/wdqs-frontend/latest/Dockerfile
+++ b/wdqs-frontend/latest/Dockerfile
@@ -18,7 +18,7 @@ COPY --from=fetcher /wikidata-query-gui-master /tmp/wikidata-query-gui-master
 WORKDIR /tmp/wikidata-query-gui-master
 
 # Put wdqs gui in the right place
-RUN apk --no-cache add --virtual build-dependencies ca-certificates~=20190108 git~=2.20 nodejs~=10 npm~=10 jq~=1.6 python~=2.7 make~=4.2 g++~=8.3
+RUN apk --no-cache add --virtual build-dependencies ca-certificates~=20190108 git~=2.22 nodejs~=10 npm~=10 jq~=1.6 python~=2.7 make~=4.2 g++~=8.3
 
 # TODO do npm build instead of leaving any dev node modules hanging around
 RUN mv package.json package.json.orig \


### PR DESCRIPTION
Version mismatch was causing failures of builds for changes targetting master, e.g. https://travis-ci.org/wmde/wikibase-docker/builds/589929341