### PR TITLE
add restart on-failure for all docker containers (needed for production)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     depends_on:
     - mysql
     - elasticsearch
-    restart: on-failure
+    restart: unless-stopped
     networks:
       default:
         aliases:
@@ -47,7 +47,7 @@ services:
       - QS_PUBLIC_SCHEME_HOST_AND_PORT=http://localhost:9191
   mysql:
     image: mariadb:10.3
-    restart: on-failure
+    restart: unless-stopped
     volumes:
       - mediawiki-mysql-data:/var/lib/mysql
     environment:
@@ -62,7 +62,7 @@ services:
          - mysql.svc
   wdqs-frontend:
     image: wikibase/wdqs-frontend:latest
-    restart: on-failure
+    restart: unless-stopped
     ports:
     # CONFIG - Change the 8282 here to expose the Query Service UI on a different port
      - "8282:80"
@@ -77,7 +77,7 @@ services:
       - WDQS_HOST=wdqs-proxy.svc
   wdqs:
     image: wikibase/wdqs:0.3.2
-    restart: on-failure
+    restart: unless-stopped
     volumes:
       - query-service-data:/wdqs/data
     command: /runBlazegraph.sh
@@ -93,7 +93,7 @@ services:
       - 9999
   wdqs-proxy:
     image: wikibase/wdqs-proxy
-    restart: on-failure
+    restart: unless-stopped
     environment:
       - PROXY_PASS_HOST=wdqs.svc:9999
     ports:
@@ -106,7 +106,7 @@ services:
          - wdqs-proxy.svc
   wdqs-updater:
     image: wikibase/wdqs:0.3.2
-    restart: on-failure
+    restart: unless-stopped
     command: /runUpdate.sh
     depends_on:
     - wdqs
@@ -121,7 +121,7 @@ services:
      - WDQS_PORT=9999
   elasticsearch:
     image: wikibase/elasticsearch:5.6.14-extra
-    restart: on-failure
+    restart: unless-stopped
     networks:
       default:
         aliases:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       - QS_PUBLIC_SCHEME_HOST_AND_PORT=http://localhost:9191
   mysql:
     image: mariadb:10.3
-    restart: always
+    restart: on-failure
     volumes:
       - mediawiki-mysql-data:/var/lib/mysql
     environment:
@@ -62,6 +62,7 @@ services:
          - mysql.svc
   wdqs-frontend:
     image: wikibase/wdqs-frontend:latest
+    restart: on-failure
     ports:
     # CONFIG - Change the 8282 here to expose the Query Service UI on a different port
      - "8282:80"
@@ -76,6 +77,7 @@ services:
       - WDQS_HOST=wdqs-proxy.svc
   wdqs:
     image: wikibase/wdqs:0.3.2
+    restart: on-failure
     volumes:
       - query-service-data:/wdqs/data
     command: /runBlazegraph.sh
@@ -91,6 +93,7 @@ services:
       - 9999
   wdqs-proxy:
     image: wikibase/wdqs-proxy
+    restart: on-failure
     environment:
       - PROXY_PASS_HOST=wdqs.svc:9999
     ports:
@@ -103,6 +106,7 @@ services:
          - wdqs-proxy.svc
   wdqs-updater:
     image: wikibase/wdqs:0.3.2
+    restart: on-failure
     command: /runUpdate.sh
     depends_on:
     - wdqs
@@ -117,6 +121,7 @@ services:
      - WDQS_PORT=9999
   elasticsearch:
     image: wikibase/elasticsearch:5.6.14-extra
+    restart: on-failure
     networks:
       default:
         aliases:


### PR DESCRIPTION
thanks to this PR, wikibase will restart when your server restart