### PR TITLE
adding libbz2, necessary to import dumps

### DIFF
--- a/wikibase/1.31/base/Dockerfile
+++ b/wikibase/1.31/base/Dockerfile
@@ -21,14 +21,14 @@ FROM mediawiki:1.31
 
 # Install envsubst
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends gettext-base=0.19.* && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends libbz2-dev=1.* gettext-base=0.19.* && \
     rm -rf /var/lib/apt/lists/*
 
 RUN a2enmod rewrite
 
 RUN install -d /var/log/mediawiki -o www-data
 
-RUN docker-php-ext-install calendar
+RUN docker-php-ext-install calendar bz2
 
 COPY --from=composer /Wikibase /var/www/html/extensions/Wikibase
 COPY wait-for-it.sh /wait-for-it.sh

--- a/wikibase/1.32/base/Dockerfile
+++ b/wikibase/1.32/base/Dockerfile
@@ -21,14 +21,14 @@ FROM mediawiki:1.32
 
 # Install envsubst
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends gettext-base=0.19.* && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends libbz2-dev=1.* gettext-base=0.19.* && \
     rm -rf /var/lib/apt/lists/*
 
 RUN a2enmod rewrite
 
 RUN install -d /var/log/mediawiki -o www-data
 
-RUN docker-php-ext-install calendar
+RUN docker-php-ext-install calendar bz2
 
 COPY --from=composer /Wikibase /var/www/html/extensions/Wikibase
 COPY wait-for-it.sh /wait-for-it.sh

--- a/wikibase/1.33/base/Dockerfile
+++ b/wikibase/1.33/base/Dockerfile
@@ -21,14 +21,14 @@ FROM mediawiki:1.33
 
 # Install envsubst
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends gettext-base=0.19.* && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends libbz2-dev=1.* gettext-base=0.19.* && \
     rm -rf /var/lib/apt/lists/*
 
 RUN a2enmod rewrite
 
 RUN install -d /var/log/mediawiki -o www-data
 
-RUN docker-php-ext-install calendar
+RUN docker-php-ext-install calendar bz2
 
 COPY --from=composer /Wikibase /var/www/html/extensions/Wikibase
 COPY wait-for-it.sh /wait-for-it.sh


### PR DESCRIPTION
hello, I was trying to load a wikidata dump into wikibase and the importDump php script was failing to load the wikidata imports because those are compressed in bzip2.
adding the proposed lines in the DockerFile would install the library and the php package.