### PR TITLE
Drop --depth from quickstatement git clone command

### DIFF
--- a/quickstatements/latest/Dockerfile
+++ b/quickstatements/latest/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && \
     apt-get install --yes --no-install-recommends git=1:2.* ca-certificates=201* && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN git clone --depth 1 https://phabricator.wikimedia.org/source/tool-quickstatements.git quickstatements
+RUN git clone https://phabricator.wikimedia.org/source/tool-quickstatements.git quickstatements
 RUN git clone --depth 1 https://bitbucket.org/magnusmanske/magnustools.git magnustools
 
 RUN rm -rf quickstatements/.git


### PR DESCRIPTION
It's currently broken: T240862
The git repo is super small, plus this is temporary to make travis green

Bug: T240862