### PR TITLE
wdqs: don't tag 0.3.6 build as latest on travis

### DIFF
--- a/wdqs/0.3.6/.travis/build-deploy.sh
+++ b/wdqs/0.3.6/.travis/build-deploy.sh
@@ -2,7 +2,7 @@
 #Oneline for full directory name see: https://stackoverflow.com/questions/59895/getting-the-source-directory-of-a-bash-script-from-within
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 set -e
-docker build "$DIR/../" -t wikibase/wdqs:0.3.6 -t wikibase/wdqs:latest
+docker build "$DIR/../" -t wikibase/wdqs:0.3.6
 
 if [ "$SHOULD_DOCKER_PUSH" = true ]; then
     docker push wikibase/wdqs:0.3.6


### PR DESCRIPTION
It was not pushed, so there should have been no real effect outside of
that volatile travis CI system.