### PR TITLE
Fix WikibaseCirrusSearch

### DIFF
--- a/elasticsearch/5.6.14-extra/Dockerfile
+++ b/elasticsearch/5.6.14-extra/Dockerfile
@@ -1,3 +1,3 @@
 FROM elasticsearch:5.6.14
 RUN ./bin/elasticsearch-plugin install org.wikimedia.search:extra:5.6.14
-
+RUN ./bin/elasticsearch-plugin install org.wikimedia.search.highlighter:experimental-highlighter-elasticsearch-plugin:5.6.14


### PR DESCRIPTION
I couldn't get WikibaseCirrusSearch to work with a fresh Wikibase, `wbsearchentities` always returned zero results.

Adding `cirrusDumpResult` to my query, I found that it complained about an experimental highlighter not being available:

```json
"failures": [
    {
        "shard": 2,
        "index": "my_wiki_general_first",
        "node": "Ox1eB1khS2KHupTtPY-tIw",
        "reason": {
            "type": "illegal_argument_exception",
            "reason": "unknown highlighter type [experimental] for the field [labels.anp.prefix]"
        }
    }
]
```

After adding `org.wikimedia.search.highlighter:experimental-highlighter-elasticsearch-plugin:5.6.14`, everything worked as expected!

--- 
Phabricator: https://phabricator.wikimedia.org/T250908