### PR TITLE
Update Elasticsearch: 5.6.14 -> 6.5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
  - IMAGE_PATH=wdqs-proxy/latest/
  - IMAGE_PATH=quickstatements/latest/
  - IMAGE_PATH=elasticsearch/5.6.14-extra/
+ - IMAGE_PATH=elasticsearch/6.5.4-extra/
 
 script:
  - source ./.travis/docker-push-setup.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,7 +120,7 @@ services:
      - WDQS_HOST=wdqs.svc
      - WDQS_PORT=9999
   elasticsearch:
-    image: wikibase/elasticsearch:5.6.14-extra
+    image: wikibase/elasticsearch:6.5.4-extra
     restart: unless-stopped
     networks:
       default:

--- a/elasticsearch/6.5.4-extra/.travis/build-deploy.sh
+++ b/elasticsearch/6.5.4-extra/.travis/build-deploy.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#Oneline for full directory name see: https://stackoverflow.com/questions/59895/getting-the-source-directory-of-a-bash-script-from-within
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+set -e
+docker build "$DIR/../" -t wikibase/elasticsearch:6.5.4-extra -t wikibase/elasticsearch:latest
+
+if [ "$SHOULD_DOCKER_PUSH" = true ]; then
+    docker push wikibase/elasticsearch:6.5.4-extra
+    docker push wikibase/elasticsearch:latest
+fi

--- a/elasticsearch/6.5.4-extra/Dockerfile
+++ b/elasticsearch/6.5.4-extra/Dockerfile
@@ -1,0 +1,3 @@
+FROM elasticsearch:6.5.4
+RUN ./bin/elasticsearch-plugin install org.wikimedia.search:extra:6.5.4
+RUN ./bin/elasticsearch-plugin install org.wikimedia.search.highlighter:experimental-highlighter-elasticsearch-plugin:6.5.4

--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -2,8 +2,8 @@
 
 Wikibase needs the extra plugin for elasticsearch from here:
 
-https://mvnrepository.com/artifact/org.wikimedia.search/extra/5.6.14
+https://mvnrepository.com/artifact/org.wikimedia.search/extra/6.5.4
 
 Image name                              | Parent image             
 --------------------------------------- | ------------------------ 
-`wikibase/elasticsearch` : `5.6.14-extra`, `latest`     | [elasticsearch:5.6.14](https://hub.docker.com/_/elasticsearch/) 
+`wikibase/elasticsearch` : `6.5.4-extra`, `latest`     | [elasticsearch:6.5.4](https://hub.docker.com/_/elasticsearch/)


### PR DESCRIPTION
Since Elasticsearch 6.5.4 is the version recommended with Mediawiki 1.34 per https://www.mediawiki.org/wiki/Extension:CirrusSearch#Dependencies
