### PR TITLE
Fix wdqs-frontend build

### DIFF
--- a/wdqs-frontend/latest/Dockerfile
+++ b/wdqs-frontend/latest/Dockerfile
@@ -18,7 +18,7 @@ COPY --from=fetcher /wikidata-query-gui-master /tmp/wikidata-query-gui-master
 WORKDIR /tmp/wikidata-query-gui-master
 
 # Put wdqs gui in the right place
-RUN apk --no-cache add --virtual build-dependencies ca-certificates~=20190108 git~=2.22 nodejs~=10 npm~=10 jq~=1.6 python~=2.7 make~=4.2 g++~=8.3
+RUN apk --no-cache add --virtual build-dependencies ca-certificates~=20191127-r0 git~=2.22 nodejs~=10 npm~=10 jq~=1.6 python~=2.7 make~=4.2 g++~=8.3
 
 # TODO do npm build instead of leaving any dev node modules hanging around
 RUN mv package.json package.json.orig \

--- a/wdqs-frontend/legacy/Dockerfile
+++ b/wdqs-frontend/legacy/Dockerfile
@@ -18,7 +18,7 @@ COPY --from=fetcher /wikidata-query-gui-master /tmp/wikidata-query-gui-master
 WORKDIR /tmp/wikidata-query-gui-master
 
 # Put wdqs gui in the right place
-RUN apk --no-cache add --virtual build-dependencies ca-certificates~=20190108 git~=2.22 nodejs~=10 npm~=10 jq~=1.6 python~=2.7 make~=4.2 g++~=8.3
+RUN apk --no-cache add --virtual build-dependencies ca-certificates~=20191127-r0 git~=2.22 nodejs~=10 npm~=10 jq~=1.6 python~=2.7 make~=4.2 g++~=8.3
 
 # TODO do npm build instead of leaving any dev node modules hanging around
 RUN mv package.json package.json.orig \


### PR DESCRIPTION
Fixes the broken wdqs-frontend  build (https://travis-ci.org/github/wmde/wikibase-docker/builds/678158255)

```
ERROR: unsatisfiable constraints:
  ca-certificates-20191127-r0:
    breaks: build-dependencies-20200422.132254[ca-certificates~20190108]
    satisfies: nodejs-10.19.0-r0[ca-certificates]
               libcurl-7.66.0-r0[ca-certificates]
```