### PR TITLE
Use Wikibase 1.34 by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ version: '3'
 
 services:
   wikibase:
-    image: wikibase/wikibase:1.33-bundle
+    image: wikibase/wikibase:1.34-bundle
     links:
       - mysql
     ports:


### PR DESCRIPTION
1.34 seems to be running fine. Can we have it as default?