### PR TITLE
No longer run wdqs process as root

### DIFF
--- a/wdqs/0.3.10/Dockerfile
+++ b/wdqs/0.3.10/Dockerfile
@@ -15,9 +15,12 @@ FROM openjdk:8-jdk-alpine
 # Install gettext for envsubst command, (it needs libintl package)
 # Install curl for the loadData.sh wdqs script (if someone needs it)
 RUN set -x ; \
-    apk --no-cache add bash=\<4.5.0 gettext=\<0.19.8.2 libintl=\<0.19.8.2 curl=\<7.64.999
+    apk --no-cache add bash=\<4.5.0 gettext=\<0.19.8.2 libintl=\<0.19.8.2 curl=\<7.64.999 su-exec=\~0.2
 
-COPY --from=fetcher /service-0.3.10-SNAPSHOT /wdqs
+RUN addgroup -g 66 -S blazegraph
+RUN adduser -S -G blazegraph -u 666 -s /bin/bash blazegraph
+
+COPY --from=fetcher --chown=blazegraph:blazegraph /service-0.3.10-SNAPSHOT /wdqs
 
 # Don't set a memory limit otherwise bad things happen (OOMs)
 ENV MEMORY=""\
@@ -29,15 +32,11 @@ ENV MEMORY=""\
 
 WORKDIR /wdqs
 
-COPY wait-for-it.sh /wait-for-it.sh
-COPY entrypoint.sh /entrypoint.sh
-COPY runBlazegraph.sh /runBlazegraph.sh
-COPY runUpdate.sh /runUpdate.sh
-COPY mwservices.json /templates/mwservices.json
-COPY RWStore.properties /wdqs/RWStore.properties
-COPY whitelist.txt /wdqs/whitelist.txt
+COPY --chown=blazegraph:blazegraph wait-for-it.sh entrypoint.sh runBlazegraph.sh runUpdate.sh /
+COPY --chown=blazegraph:blazegraph mwservices.json /templates/mwservices.json
+COPY --chown=blazegraph:blazegraph RWStore.properties whitelist.txt /wdqs/
 
-# TODO is this actually needed?
+# TODO this shouldn't be needed, but CI currently doesnt check for the +x bit, which is why this line is here
 RUN chmod +x /wdqs/runUpdate.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/wdqs/0.3.10/entrypoint.sh
+++ b/wdqs/0.3.10/entrypoint.sh
@@ -17,5 +17,12 @@ export BLAZEGRAPH_OPTS="-DwikibaseHost=${WIKIBASE_HOST}"
 export UPDATER_OPTS="-DwikibaseHost=${WIKIBASE_HOST} -DwikibaseMaxDaysBack=${WIKIBASE_MAX_DAYS_BACK}"
 
 envsubst < /templates/mwservices.json > /wdqs/mwservices.json
+chown 666:66 /wdqs/mwservices.json
 
-exec "$@"
+# The data directory should always be owned by the blazegraph user
+# This used to be owned by root (https://phabricator.wikimedia.org/T237248)
+if [ -d /wdqs/data/ ]; then
+  chown 666:66 -R /wdqs/data/
+fi
+
+su-exec 666:66 "$@"

--- a/wdqs/0.3.6/Dockerfile
+++ b/wdqs/0.3.6/Dockerfile
@@ -15,9 +15,12 @@ FROM openjdk:8-jdk-alpine
 # Install gettext for envsubst command, (it needs libintl package)
 # Install curl for the loadData.sh wdqs script (if someone needs it)
 RUN set -x ; \
-    apk --no-cache add bash=\<4.5.0 gettext=\<0.19.8.2 libintl=\<0.19.8.2 curl=\<7.64.999
+    apk --no-cache add bash=\<4.5.0 gettext=\<0.19.8.2 libintl=\<0.19.8.2 curl=\<7.64.999 su-exec=\~0.2
 
-COPY --from=fetcher /service-0.3.6-SNAPSHOT /wdqs
+RUN addgroup -g 66 -S blazegraph
+RUN adduser -S -G blazegraph -u 666 -s /bin/bash blazegraph
+
+COPY --from=fetcher --chown=blazegraph:blazegraph /service-0.3.6-SNAPSHOT /wdqs
 
 # Don't set a memory limit otherwise bad things happen (OOMs)
 ENV MEMORY=""\
@@ -29,15 +32,11 @@ ENV MEMORY=""\
 
 WORKDIR /wdqs
 
-COPY wait-for-it.sh /wait-for-it.sh
-COPY entrypoint.sh /entrypoint.sh
-COPY runBlazegraph.sh /runBlazegraph.sh
-COPY runUpdate.sh /runUpdate.sh
-COPY mwservices.json /templates/mwservices.json
-COPY RWStore.properties /wdqs/RWStore.properties
-COPY whitelist.txt /wdqs/whitelist.txt
+COPY --chown=blazegraph:blazegraph wait-for-it.sh entrypoint.sh runBlazegraph.sh runUpdate.sh /
+COPY --chown=blazegraph:blazegraph mwservices.json /templates/mwservices.json
+COPY --chown=blazegraph:blazegraph RWStore.properties whitelist.txt /wdqs/
 
-# TODO is this actually needed?
+# TODO this shouldn't be needed, but CI currently doesnt check for the +x bit, which is why this line is here
 RUN chmod +x /wdqs/runUpdate.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/wdqs/0.3.6/entrypoint.sh
+++ b/wdqs/0.3.6/entrypoint.sh
@@ -17,5 +17,12 @@ export BLAZEGRAPH_OPTS="-DwikibaseHost=${WIKIBASE_HOST}"
 export UPDATER_OPTS="-DwikibaseHost=${WIKIBASE_HOST} -DwikibaseMaxDaysBack=${WIKIBASE_MAX_DAYS_BACK}"
 
 envsubst < /templates/mwservices.json > /wdqs/mwservices.json
+chown 666:66 /wdqs/mwservices.json
 
-exec "$@"
+# The data directory should always be owned by the blazegraph user
+# This used to be owned by root (https://phabricator.wikimedia.org/T237248)
+if [ -d /wdqs/data/ ]; then
+  chown 666:66 -R /wdqs/data/
+fi
+
+su-exec 666:66 "$@"


### PR DESCRIPTION
This change makes use of https://github.com/ncopa/su-exec which is
included as a base alpine package.
gosu is recommended by
https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
however gosu itself suggests you might want to use su-exec, especially
if you are using alpine.

Any previous wdqs/data directories will be chowned to blazegraph.
the wdqs is now also owned by the blazegraph user.

When chowning the data dir I considered checking who owned it before
running chown, but chown should be fine, and also shoudln't be slow etc,
as the data directory should not include many files.

Bug: T237248