### PR TITLE
Fix QuickStatements image

### DIFF
--- a/quickstatements/README.md
+++ b/quickstatements/README.md
@@ -22,14 +22,14 @@ Variable                   | Default  | Description
 
 Directory                                   | Description                                                                   
 ---------------------------------           | ------------------------------------------------------------------------------
-`/var/www/html/quickstatements`             | Base quickstatements directory                                                
-`/var/www/html/quickstatements/public_html` | The Apache Root folder                                                        
-`/var/www/html/magnustools`                 | Base magnustools directory                                                    
+`/data/project/quickstatements`             | Base quickstatements directory                                                
+`/data/project/quickstatements/public_html` | The Apache Root folder                                                        
+`/data/project/magnustools`                 | Base magnustools directory                                                    
 
 File                      | Description                                                                                                                              
 ------------------------- | ------------------------------------------------------------------------------                                                           
-`/templates/config.json`  | Template for Quickstatements' config.json (substituted to `/var/www/html/quickstatements/public_html/config.json` at runtime)            
-`/templates/oauth.ini`    | Template for Quickstatements' oauth.ini (substituted to `/var/www/html/quickstatements/oauth.ini` at runtime)                            
+`/templates/config.json`  | Template for Quickstatements' config.json (substituted to `/data/project/quickstatements/public_html/config.json` at runtime)            
+`/templates/oauth.ini`    | Template for Quickstatements' oauth.ini (substituted to `/data/project/quickstatements/oauth.ini` at runtime)                            
 `/templates/php.ini`      | php config (default provided sets date.timezone to prevent php complaining substituted to `/usr/local/etc/php/conf.d/php.ini` at runtime)
 
 

--- a/quickstatements/latest/Dockerfile
+++ b/quickstatements/latest/Dockerfile
@@ -27,10 +27,11 @@ FROM php:7.2-apache
 # Install envsubst
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends gettext-base=0.19.* jq=1.5* && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    mkdir -p /data/project/
 
-COPY --from=composer /quickstatements /var/www/html/quickstatements
-COPY --from=fetcher /magnustools /var/www/html/magnustools
+COPY --from=composer /quickstatements /data/project/quickstatements
+COPY --from=fetcher /magnustools /data/project/magnustools
 
 COPY entrypoint.sh /entrypoint.sh
 
@@ -38,7 +39,7 @@ COPY config.json /templates/config.json
 COPY oauth.ini /templates/oauth.ini
 COPY php.ini /templates/php.ini
 
-ENV APACHE_DOCUMENT_ROOT /var/www/html/quickstatements/public_html
+ENV APACHE_DOCUMENT_ROOT /data/project/quickstatements/public_html
 RUN sed -ri -e "s!/var/www/html!${APACHE_DOCUMENT_ROOT}!g" /etc/apache2/sites-available/*.conf
 RUN sed -ri -e "s!/var/www/!${APACHE_DOCUMENT_ROOT}!g" /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
 

--- a/quickstatements/latest/Dockerfile
+++ b/quickstatements/latest/Dockerfile
@@ -5,7 +5,12 @@ RUN apt-get update && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN git clone https://phabricator.wikimedia.org/source/tool-quickstatements.git quickstatements
-RUN git clone --depth 1 https://bitbucket.org/magnusmanske/magnustools.git magnustools
+
+RUN git clone https://bitbucket.org/magnusmanske/magnustools.git magnustools && \
+    git --git-dir=./magnustools/.git checkout d791f84cba556a29fa5c84543b3c4717a0c63876
+    # https://phabricator.wikimedia.org/T259389:
+    # Per 2020-07-31, this seems to be the latest working commit. Starting from the next commit,
+    # `public_html/php/wikidata.php` requires a non-existing file `public_html/php/WikidataItem.php`.
 
 RUN rm -rf quickstatements/.git
 RUN rm -rf magnustools/.git

--- a/quickstatements/latest/config.json
+++ b/quickstatements/latest/config.json
@@ -1,6 +1,6 @@
 {
 	"site" : "${MW_SITE_NAME}" ,
-	"bot_config_file" : "/var/www/html/bot.ini" ,
+	"bot_config_file" : "/data/project/bot.ini" ,
 	"logfile" : "/var/log/quickstatements/tool.log" ,
 	"sites" : {
 		"${MW_SITE_NAME}" : {

--- a/quickstatements/latest/entrypoint.sh
+++ b/quickstatements/latest/entrypoint.sh
@@ -13,7 +13,7 @@ if [[ -v "$OAUTH_CONSUMER_KEY" && "$OAUTH_CONSUMER_SECRET" ]]; then
     envsubst < /templates/oauth.ini > /quickstatements/data/oauth.ini;
 fi
 
-envsubst < /templates/config.json > /var/www/html/quickstatements/public_html/config.json
+envsubst < /templates/config.json > /data/project/quickstatements/public_html/config.json
 envsubst < /templates/php.ini > /usr/local/etc/php/conf.d/php.ini
 
 docker-php-entrypoint apache2-foreground


### PR DESCRIPTION
This is a quickfix for https://phabricator.wikimedia.org/T259389, that
- reverts to the latest working commit of magnustools
- fixes absolute import issues by moving the project to the same structure as Toolforge (`/data/project/...`)

I had to cook together something to get it working on my own server, so I thought I could also share it here with others running into the same issue.

I'm not sure if this PR is up to standards though, or it's too drastic to move the stuff to `/data/project/...`? An alternative could be to revert to an even older commit, but on the other hand, I'm not sure if there are any downsides of moving.

Another alternative could be to wait for an upstream fix.