### PR TITLE
Add 1.35, but don't build on travis yet

### DIFF
--- a/wikibase/1.35/.travis/build-deploy.sh
+++ b/wikibase/1.35/.travis/build-deploy.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#Oneline for full directory name see: https://stackoverflow.com/questions/59895/getting-the-source-directory-of-a-bash-script-from-within
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+set -e
+docker build "$DIR/../base" -t wikibase/wikibase:1.35 -t wikibase/wikibase:1.35-base -t wikibase/wikibase:latest -t wikibase/wikibase:latest-base
+docker build "$DIR/../bundle" -t wikibase/wikibase:1.35-bundle -t wikibase/wikibase:latest-bundle
+
+#if [ "$SHOULD_DOCKER_PUSH" = true ]; then
+#    docker push wikibase/wikibase:1.35
+#    docker push wikibase/wikibase:latest
+#    docker push wikibase/wikibase:1.35-base
+#    docker push wikibase/wikibase:latest-base
+#    docker push wikibase/wikibase:1.35-bundle
+#    docker push wikibase/wikibase:latest-bundle
+#fi

--- a/wikibase/1.35/base/Dockerfile
+++ b/wikibase/1.35/base/Dockerfile
@@ -1,0 +1,47 @@
+FROM ubuntu:xenial as fetcher
+
+COPY download-extension.sh .
+RUN apt-get update && \
+    apt-get install --yes --no-install-recommends unzip=6.* jq=1.* curl=7.* ca-certificates=201* && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN bash download-extension.sh Wikibase;\
+tar xzf Wikibase.tar.gz;
+
+
+FROM mediawiki:1.35 as collector
+COPY --from=fetcher /Wikibase /var/www/html/extensions/Wikibase
+
+
+FROM composer as composer
+COPY --from=collector /var/www/html /var/www/html
+WORKDIR /var/www/html/
+COPY composer.local.json /var/www/html/composer.local.json
+RUN composer install --no-dev
+
+
+FROM mediawiki:1.35
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends libbz2-dev=1.* gettext-base=0.19.* && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN a2enmod rewrite
+
+RUN install -d /var/log/mediawiki -o www-data
+
+RUN docker-php-ext-install calendar bz2
+
+COPY --from=composer /var/www/html /var/www/html
+COPY wait-for-it.sh /wait-for-it.sh
+COPY entrypoint.sh /entrypoint.sh
+COPY LocalSettings.php.template /LocalSettings.php.template
+COPY htaccess /var/www/html/.htaccess
+
+RUN ln -s /var/www/html/ /var/www/html/w
+
+ENV MW_SITE_NAME=wikibase-docker\
+    MW_SITE_LANG=en
+
+ENTRYPOINT ["/bin/bash"]
+CMD ["/entrypoint.sh"]

--- a/wikibase/1.35/base/LocalSettings.php.template
+++ b/wikibase/1.35/base/LocalSettings.php.template
@@ -1,0 +1,57 @@
+<?php
+/**
+ * ----------------------------------------------------------------------------------------
+ * This file is provided by the wikibase/wikibase docker image.
+ * This file will be passed through envsubst which will replace "${DOLLAR}" with "$".
+ * If you want to change MediaWiki or Wikibase settings then either mount a file over this
+ * template and or run a different entrypoint.
+ * ----------------------------------------------------------------------------------------
+ */
+
+## Database settings
+## Environment variables will be substituted in here.
+${DOLLAR}wgDBserver = "${DB_SERVER}";
+${DOLLAR}wgDBname = "${DB_NAME}";
+${DOLLAR}wgDBuser = "${DB_USER}";
+${DOLLAR}wgDBpassword = "${DB_PASS}";
+
+## Logs
+## Save these logs inside the container
+${DOLLAR}wgDebugLogGroups = array(
+	'resourceloader' => '/var/log/mediawiki/resourceloader.log',
+	'exception' => '/var/log/mediawiki/exception.log',
+	'error' => '/var/log/mediawiki/error.log',
+);
+
+## Site Settings
+# TODO pass in the rest of this with env vars?
+${DOLLAR}wgServer = WebRequest::detectServer();
+${DOLLAR}wgShellLocale = "en_US.utf8";
+${DOLLAR}wgLanguageCode = "${MW_SITE_LANG}";
+${DOLLAR}wgSitename = "${MW_SITE_NAME}";
+${DOLLAR}wgMetaNamespace = "Project";
+# Configured web paths & short URLs
+# This allows use of the /wiki/* path
+## https://www.mediawiki.org/wiki/Manual:Short_URL
+${DOLLAR}wgScriptPath = "/w";        // this should already have been configured this way
+${DOLLAR}wgArticlePath = "/wiki/${DOLLAR}1";
+
+#Set Secret
+${DOLLAR}wgSecretKey = "${MW_WG_SECRET_KEY}";
+
+## RC Age
+# https://www.mediawiki.org/wiki/Manual:$wgRCMaxAge
+# Items in the recentchanges table are periodically purged; entries older than this many seconds will go.
+# The query service (by default) loads data from recent changes
+# Set this to 1 year to avoid any changes being removed from the RC table over a shorter period of time.
+${DOLLAR}wgRCMaxAge = 365 * 24 * 3600;
+
+wfLoadSkin( 'Vector' );
+
+## Wikibase
+# Load Wikibase repo, client & lib with the example / default settings.
+require_once "${DOLLAR}IP/extensions/Wikibase/lib/WikibaseLib.php";
+require_once "${DOLLAR}IP/extensions/Wikibase/repo/Wikibase.php";
+require_once "${DOLLAR}IP/extensions/Wikibase/repo/ExampleSettings.php";
+require_once "${DOLLAR}IP/extensions/Wikibase/client/WikibaseClient.php";
+require_once "${DOLLAR}IP/extensions/Wikibase/client/ExampleSettings.php";

--- a/wikibase/1.35/base/LocalSettings.php.template
+++ b/wikibase/1.35/base/LocalSettings.php.template
@@ -49,8 +49,7 @@ ${DOLLAR}wgRCMaxAge = 365 * 24 * 3600;
 wfLoadSkin( 'Vector' );
 
 ## Wikibase
-# Load Wikibase repo, client & lib with the example / default settings.
-require_once "${DOLLAR}IP/extensions/Wikibase/lib/WikibaseLib.php";
+# Load Wikibase repo & client with the example / default settings.
 require_once "${DOLLAR}IP/extensions/Wikibase/repo/Wikibase.php";
 require_once "${DOLLAR}IP/extensions/Wikibase/repo/ExampleSettings.php";
 require_once "${DOLLAR}IP/extensions/Wikibase/client/WikibaseClient.php";

--- a/wikibase/1.35/base/composer.local.json
+++ b/wikibase/1.35/base/composer.local.json
@@ -1,0 +1,10 @@
+{
+	"extra": {
+		"merge-plugin": {
+			"include": [
+				"extensions/*/composer.json",
+				"skins/*/composer.json"
+			]
+		}
+	}
+}

--- a/wikibase/1.35/base/download-extension.sh
+++ b/wikibase/1.35/base/download-extension.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+EXTENSION=$1
+
+TAR_URL=$(curl -s "https://www.mediawiki.org/w/api.php?action=query&list=extdistbranches&edbexts=$EXTENSION&formatversion=2&format=json" | jq -r ".query.extdistbranches.extensions.$EXTENSION.REL1_35")
+curl -s "$TAR_URL" -o "$EXTENSION".tar.gz

--- a/wikibase/1.35/base/entrypoint.sh
+++ b/wikibase/1.35/base/entrypoint.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# This file is provided by the wikibase/wikibase docker image.
+
+# Test if required environment variables have been set
+REQUIRED_VARIABLES=(MW_ADMIN_NAME MW_ADMIN_PASS MW_ADMIN_EMAIL MW_WG_SECRET_KEY DB_SERVER DB_USER DB_PASS DB_NAME)
+for i in ${REQUIRED_VARIABLES[@]}; do
+    eval THISSHOULDBESET=\$$i
+    if [ -z "$THISSHOULDBESET" ]; then
+    echo "$i is required but isn't set. You should pass it to docker. See: https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file";
+    exit 1;
+    fi
+done
+
+set -eu
+
+# Wait for the db to come up
+/wait-for-it.sh $DB_SERVER -t 300
+# Sometimes it appears to come up and then go back down meaning MW install fails
+# So wait for a second and double check!
+sleep 1
+/wait-for-it.sh $DB_SERVER -t 300
+
+# Run extra scripts everytime
+if [ -f /extra-entrypoint-run-first.sh ]; then
+    source /extra-entrypoint-run-first.sh
+fi
+
+# Do the mediawiki install (only if LocalSettings doesn't already exist)
+if [ ! -e "/var/www/html/LocalSettings.php" ]; then
+    php /var/www/html/maintenance/install.php --dbuser $DB_USER --dbpass $DB_PASS --dbname $DB_NAME --dbserver $DB_SERVER --lang $MW_SITE_LANG --pass $MW_ADMIN_PASS $MW_SITE_NAME $MW_ADMIN_NAME
+    php /var/www/html/maintenance/resetUserEmail.php --no-reset-password $MW_ADMIN_NAME $MW_ADMIN_EMAIL
+
+    # Copy our LocalSettings into place after install from the template
+    # https://stackoverflow.com/a/24964089/4746236
+    export DOLLAR='$'
+    envsubst < /LocalSettings.php.template > /var/www/html/LocalSettings.php
+
+    # Run update.php to install Wikibase
+    php /var/www/html/maintenance/update.php --quick
+
+    # Run extrascripts on first run
+    if [ -f /extra-install.sh ]; then
+        source /extra-install.sh
+    fi
+fi
+
+# Run the actual entry point
+docker-php-entrypoint apache2-foreground

--- a/wikibase/1.35/base/htaccess
+++ b/wikibase/1.35/base/htaccess
@@ -1,0 +1,15 @@
+# This file is provided by the wikibase/wikibase docker image.
+## http://www.mediawiki.org/wiki/Manual:Short_URL/Apache
+
+# Enable the rewrite engine
+RewriteEngine On
+
+# Short url for wiki pages
+RewriteRule ^/?wiki(/.*)?$ %{DOCUMENT_ROOT}/w/index.php [L]
+
+# Redirect / to Main Page
+RewriteRule ^/*$ %{DOCUMENT_ROOT}/w/index.php [L]
+
+# rewrite /entity/ URLs like wikidata per
+# https://meta.wikimedia.org/wiki/Wikidata/Notes/URI_scheme
+RewriteRule ^/?entity/(.*)$ /wiki/Special:EntityData/$1 [R=303,QSA]

--- a/wikibase/1.35/base/wait-for-it.sh
+++ b/wikibase/1.35/base/wait-for-it.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# This file is provided by the wikibase/wikibase docker image.
+# Use this script to test if a given TCP host/port are available
+
+cmdname=$(basename $0)
+
+echoerr() { if [[ $QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+wait_for()
+{
+    if [[ $TIMEOUT -gt 0 ]]; then
+        echoerr "$cmdname: waiting $TIMEOUT seconds for $HOST:$PORT"
+    else
+        echoerr "$cmdname: waiting for $HOST:$PORT without a timeout"
+    fi
+    start_ts=$(date +%s)
+    while :
+    do
+        if [[ $ISBUSY -eq 1 ]]; then
+            nc -z $HOST $PORT
+            result=$?
+        else
+            (echo > /dev/tcp/$HOST/$PORT) >/dev/null 2>&1
+            result=$?
+        fi
+        if [[ $result -eq 0 ]]; then
+            end_ts=$(date +%s)
+            echoerr "$cmdname: $HOST:$PORT is available after $((end_ts - start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $QUIET -eq 1 ]]; then
+        timeout $BUSYTIMEFLAG $TIMEOUT $0 --quiet --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+    else
+        timeout $BUSYTIMEFLAG $TIMEOUT $0 --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+    fi
+    PID=$!
+    trap "kill -INT -$PID" INT
+    wait $PID
+    RESULT=$?
+    if [[ $RESULT -ne 0 ]]; then
+        echoerr "$cmdname: timeout occurred after waiting $TIMEOUT seconds for $HOST:$PORT"
+    fi
+    return $RESULT
+}
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        hostport=(${1//:/ })
+        HOST=${hostport[0]}
+        PORT=${hostport[1]}
+        shift 1
+        ;;
+        --child)
+        CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        STRICT=1
+        shift 1
+        ;;
+        -h)
+        HOST="$2"
+        if [[ $HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        PORT="$2"
+        if [[ $PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        TIMEOUT="$2"
+        if [[ $TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        CLI="$@"
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$HOST" == "" || "$PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+
+TIMEOUT=${TIMEOUT:-15}
+STRICT=${STRICT:-0}
+CHILD=${CHILD:-0}
+QUIET=${QUIET:-0}
+
+# check to see if timeout is from busybox?
+# check to see if timeout is from busybox?
+TIMEOUT_PATH=$(realpath $(which timeout))
+if [[ $TIMEOUT_PATH =~ "busybox" ]]; then
+        ISBUSY=1
+        BUSYTIMEFLAG="-t"
+else
+        ISBUSY=0
+        BUSYTIMEFLAG=""
+fi
+
+if [[ $CHILD -gt 0 ]]; then
+    wait_for
+    RESULT=$?
+    exit $RESULT
+else
+    if [[ $TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        RESULT=$?
+    else
+        wait_for
+        RESULT=$?
+    fi
+fi
+
+if [[ $CLI != "" ]]; then
+    if [[ $RESULT -ne 0 && $STRICT -eq 1 ]]; then
+        echoerr "$cmdname: strict mode, refusing to execute subprocess"
+        exit $RESULT
+    fi
+    exec $CLI
+else
+    exit $RESULT
+fi

--- a/wikibase/1.35/bundle/Dockerfile
+++ b/wikibase/1.35/bundle/Dockerfile
@@ -1,0 +1,53 @@
+FROM ubuntu:xenial as fetcher
+
+RUN apt-get update && \
+    apt-get install --yes --no-install-recommends unzip=6.* jq=1.* curl=7.* ca-certificates=201* && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+COPY download-extension.sh .
+ADD https://github.com/wikidata/WikibaseImport/archive/master.tar.gz /WikibaseImport.tar.gz
+RUN bash download-extension.sh OAuth;\
+bash download-extension.sh Elastica;\
+bash download-extension.sh CirrusSearch;\
+bash download-extension.sh WikibaseCirrusSearch;\
+bash download-extension.sh UniversalLanguageSelector;\
+bash download-extension.sh cldr;\
+bash download-extension.sh EntitySchema;\
+tar xzf OAuth.tar.gz;\
+tar xzf Elastica.tar.gz;\
+tar xzf CirrusSearch.tar.gz;\
+tar xzf WikibaseCirrusSearch.tar.gz;\
+tar xzf UniversalLanguageSelector.tar.gz;\
+tar xzf cldr.tar.gz;\
+tar xzf WikibaseImport.tar.gz;\
+tar xzf EntitySchema.tar.gz;\
+rm ./*.tar.gz
+
+FROM wikibase/wikibase:1.35 as collector
+COPY --from=fetcher /WikibaseImport-master /var/www/html/extensions/WikibaseImport
+COPY --from=fetcher /Elastica /var/www/html/extensions/Elastica
+COPY --from=fetcher /OAuth /var/www/html/extensions/OAuth
+COPY --from=fetcher /CirrusSearch /var/www/html/extensions/CirrusSearch
+COPY --from=fetcher /WikibaseCirrusSearch /var/www/html/extensions/WikibaseCirrusSearch
+COPY --from=fetcher /UniversalLanguageSelector /var/www/html/extensions/UniversalLanguageSelector
+COPY --from=fetcher /cldr /var/www/html/extensions/cldr
+COPY --from=fetcher /EntitySchema /var/www/html/extensions/EntitySchema
+
+FROM composer as composer
+COPY --from=collector /var/www/html /var/www/html
+WORKDIR /var/www/html/
+RUN rm /var/www/html/composer.lock
+RUN composer install --no-dev
+
+FROM wikibase/wikibase:1.35
+
+RUN apt-get update && \
+    apt-get install --yes --no-install-recommends jq=1.* && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+COPY --from=composer /var/www/html /var/www/html
+COPY LocalSettings.php.wikibase-bundle.template /LocalSettings.php.wikibase-bundle.template
+COPY extra-install.sh /
+COPY extra-entrypoint-run-first.sh /
+RUN cat /LocalSettings.php.wikibase-bundle.template >> /LocalSettings.php.template && rm /LocalSettings.php.wikibase-bundle.template
+COPY oauth.ini /templates/oauth.ini

--- a/wikibase/1.35/bundle/LocalSettings.php.wikibase-bundle.template
+++ b/wikibase/1.35/bundle/LocalSettings.php.wikibase-bundle.template
@@ -1,0 +1,27 @@
+# OAuth
+wfLoadExtension( 'OAuth' );
+${DOLLAR}wgGroupPermissions['sysop']['mwoauthproposeconsumer'] = true;
+${DOLLAR}wgGroupPermissions['sysop']['mwoauthmanageconsumer'] = true;
+${DOLLAR}wgGroupPermissions['sysop']['mwoauthviewprivate'] = true;
+${DOLLAR}wgGroupPermissions['sysop']['mwoauthupdateownconsumer'] = true;
+
+# WikibaseImport
+require_once "${DOLLAR}IP/extensions/WikibaseImport/WikibaseImport.php";
+
+# CirrusSearch
+wfLoadExtension( 'Elastica' );
+wfLoadExtension( 'CirrusSearch' );
+wfLoadExtension( 'WikibaseCirrusSearch' );
+${DOLLAR}wgCirrusSearchServers = [ '${MW_ELASTIC_HOST}' ];
+${DOLLAR}wgSearchType = 'CirrusSearch';
+${DOLLAR}wgCirrusSearchExtraIndexSettings['index.mapping.total_fields.limit'] = 5000;
+${DOLLAR}wgWBCSUseCirrus = true;
+
+# UniversalLanguageSelector
+wfLoadExtension( 'UniversalLanguageSelector' );
+
+# cldr
+wfLoadExtension( 'cldr' );
+
+#EntitySchema
+wfLoadExtension( 'EntitySchema' );

--- a/wikibase/1.35/bundle/download-extension.sh
+++ b/wikibase/1.35/bundle/download-extension.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+EXTENSION=$1
+
+TAR_URL=$(curl -s "https://www.mediawiki.org/w/api.php?action=query&list=extdistbranches&edbexts=$EXTENSION&formatversion=2&format=json" | jq -r ".query.extdistbranches.extensions.$EXTENSION.REL1_35")
+curl -s "$TAR_URL" -o "$EXTENSION".tar.gz

--- a/wikibase/1.35/bundle/extra-entrypoint-run-first.sh
+++ b/wikibase/1.35/bundle/extra-entrypoint-run-first.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+/wait-for-it.sh $MW_ELASTIC_HOST:$MW_ELASTIC_PORT -t 300

--- a/wikibase/1.35/bundle/extra-install.sh
+++ b/wikibase/1.35/bundle/extra-install.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+php /var/www/html/extensions/CirrusSearch/maintenance/updateSearchIndexConfig.php
+php /var/www/html/extensions/CirrusSearch/maintenance/forceSearchIndex.php --skipParse
+php /var/www/html/extensions/CirrusSearch/maintenance/forceSearchIndex.php --skipLinks --indexOnSkip
+
+n=0
+until [ $n -ge 5 ]
+do
+   php /var/www/html/extensions/OAuth/maintenance/createOAuthConsumer.php --approve --callbackUrl  $QS_PUBLIC_SCHEME_HOST_AND_PORT/api.php \
+	--callbackIsPrefix true --user $MW_ADMIN_NAME --name QuickStatements --description QuickStatements --version 1.0.1 \
+	--grants createeditmovepage --grants editpage --grants highvolume --jsonOnSuccess > /quickstatements/data/qs-oauth.json && break
+	n=$[$n+1]
+	sleep 5s
+done
+
+if [[ -f /quickstatements/data/qs-oauth.json ]]; then
+    export OAUTH_CONSUMER_KEY=$(jq -r '.key' /quickstatements/data/qs-oauth.json);
+    export OAUTH_CONSUMER_SECRET=$(jq -r '.secret' /quickstatements/data/qs-oauth.json);
+	envsubst < /templates/oauth.ini > /quickstatements/data/oauth.ini
+fi

--- a/wikibase/1.35/bundle/oauth.ini
+++ b/wikibase/1.35/bundle/oauth.ini
@@ -1,0 +1,5 @@
+; HTTP User-Agent header
+agent = 'Wikibase Docker QuickStatements'
+; assigned by Special:OAuthConsumerRegistration (request modelled after https://www.wikidata.org/wiki/Special:OAuthListConsumers/view/77b4ae5506dd7dbb0bb07f80e3ae3ca9)
+consumerKey = '${OAUTH_CONSUMER_KEY}'
+consumerSecret = '${OAUTH_CONSUMER_SECRET}'


### PR DESCRIPTION
1.35 is at release candidate stage but we needed it to test and make
sure it works with the changes we did with extension registration.

It works fine locally for me.

You need to build the mediawiki:1.35 yourself as it's not yet released to docker hub

Bug: T259529