### PR TITLE
Update quickstatements repo URL [Do not merge yet]

### DIFF
--- a/quickstatements/latest/Dockerfile
+++ b/quickstatements/latest/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && \
     apt-get install --yes --no-install-recommends git=1:2.* ca-certificates=201* && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN git clone https://phabricator.wikimedia.org/source/tool-quickstatements.git quickstatements
+RUN git clone https://github.com/magnusmanske/quickstatements.git quickstatements
 RUN git clone --depth 1 https://bitbucket.org/magnusmanske/magnustools.git magnustools
 
 RUN rm -rf quickstatements/.git

--- a/quickstatements/latest/config.json
+++ b/quickstatements/latest/config.json
@@ -2,6 +2,7 @@
 	"site" : "${MW_SITE_NAME}" ,
 	"bot_config_file" : "/var/www/html/bot.ini" ,
 	"logfile" : "/var/log/quickstatements/tool.log" ,
+	"valid_origin" : "${QS_PUBLIC_SCHEME_HOST_AND_PORT}" ,
 	"sites" : {
 		"${MW_SITE_NAME}" : {
 			"oauth" : {


### PR DESCRIPTION
Seems like quickstatements was moved from Diffusion to GitHub, per https://github.com/magnusmanske/quickstatements/commit/e1f0a86b85bde4942197377e2617e04cf1c376a6 . The GitHub repo contains 5 commits not found on Diffusion:

```sh
git log --oneline --graph diffusion/master..magnus-github/master
* e1f0a86 (HEAD -> master, me/master, magnus-github/master, magnus-github/HEAD) changed git repo url
* 5be6082 fix for T211369
* eb63aa8 misc
* 53c4012 misc
* c7e8d5f add COPYING
```

- [x] Added the "valid_origin" config option, which was added to QuickStatements in https://github.com/magnusmanske/quickstatements/commit/5be608271811787f039dcd643a6866c2fff45d99

- [ ] There is a callback URL which is hard-coded, waiting for https://github.com/magnusmanske/quickstatements/pull/1 to be merged

