### PR TITLE
Fix QuickStatements API url [Do not merge yet]

### DIFF
--- a/quickstatements/latest/config.json
+++ b/quickstatements/latest/config.json
@@ -14,6 +14,7 @@
 			} ,
 			"server" : "${WB_PUBLIC_HOST_AND_PORT}" ,
 			"api" : "${WIKIBASE_SCHEME_AND_HOST}/w/api.php" ,
+			"publicApi" : "${WB_PUBLIC_SCHEME_HOST_AND_PORT}/w/api.php" ,
 			"pageBase" : "${WB_PUBLIC_SCHEME_HOST_AND_PORT}/wiki/" ,
 			"toolBase" : "${QS_PUBLIC_SCHEME_HOST_AND_PORT}/" ,
 			"types" : {


### PR DESCRIPTION
QuickStatements fails to [fetch entitity data](https://github.com/magnusmanske/quickstatements/blob/e1f0a86b85bde4942197377e2617e04cf1c376a6/public_html/quickstatements.js#L504) from the MediaWiki API using the URL configured under [`config.sites[].api`](https://github.com/wmde/wikibase-docker/blob/262ffef7cc550381309c360e3e92507e85cd8bf6/quickstatements/latest/config.json#L16), because that URL is not publicly available.

My first idea was to try setting `config.sites[].api` to `$MW_PUBLIC_SCHEME_HOST_AND_PORT`. This works fine in a production scenario where the host is a public host, but not when set to something like localhost. I guess this is the reason a separate MW_PUBLIC_SCHEME_HOST_AND_PORT was introduced in the first place?

So afaics it seems like we need a new configuration parameter where we can set the public api url. I've submitted  https://github.com/magnusmanske/quickstatements/pull/2

If that PR is accepted, all we need to do here is to update `config.json`
