### PR TITLE
fix capitalisation in file names. '

### DIFF
--- a/wikibase/1.35/bundle/extra-install.sh
+++ b/wikibase/1.35/bundle/extra-install.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-php /var/www/html/extensions/CirrusSearch/maintenance/updateSearchIndexConfig.php
-php /var/www/html/extensions/CirrusSearch/maintenance/forceSearchIndex.php --skipParse
-php /var/www/html/extensions/CirrusSearch/maintenance/forceSearchIndex.php --skipLinks --indexOnSkip
+php /var/www/html/extensions/CirrusSearch/maintenance/UpdateSearchIndexConfig.php
+php /var/www/html/extensions/CirrusSearch/maintenance/ForceSearchIndex.php --skipParse
+php /var/www/html/extensions/CirrusSearch/maintenance/ForceSearchIndex.php --skipLinks --indexOnSkip
 
 n=0
 until [ $n -ge 5 ]


### PR DESCRIPTION
These maintenance scripts were moved to CapitalCase a while ago, and remaining symlinks removed [last May](https://github.com/wikimedia/mediawiki-extensions-CirrusSearch/commit/80ee6f7d63d35f7387fdfad49dba347fa163a193#diff-57cb773ae7a82c8c8aae12fa8f8d7abd).

Symptoms include search just not working, as well as this error message in the log:

`Could not open input file: /var/www/html/extensions/CirrusSearch/maintenance/updateSearchIndexConfig.php' is the associated symptom, and also search just not working'`