### PR TITLE
Fix for the a build-breaking versioning mishap

### DIFF
--- a/quickstatements/latest/Dockerfile
+++ b/quickstatements/latest/Dockerfile
@@ -10,7 +10,7 @@ RUN git clone --depth 1 https://bitbucket.org/magnusmanske/magnustools.git magnu
 RUN rm -rf quickstatements/.git
 RUN rm -rf magnustools/.git
 
-FROM composer as composer
+FROM composer:1 as composer
 
 COPY --from=fetcher /quickstatements /quickstatements
 

--- a/wikibase/1.31/base/Dockerfile
+++ b/wikibase/1.31/base/Dockerfile
@@ -13,7 +13,7 @@ FROM mediawiki:1.31 as collector
 COPY --from=fetcher /Wikibase /var/www/html/extensions/Wikibase
 
 
-FROM composer as composer
+FROM composer:1 as composer
 COPY --from=collector /var/www/html /var/www/html
 WORKDIR /var/www/html/
 COPY composer.local.json /var/www/html/composer.local.json

--- a/wikibase/1.31/bundle/Dockerfile
+++ b/wikibase/1.31/bundle/Dockerfile
@@ -27,7 +27,7 @@ COPY --from=fetcher /CirrusSearch /var/www/html/extensions/CirrusSearch
 COPY --from=fetcher /UniversalLanguageSelector /var/www/html/extensions/UniversalLanguageSelector
 COPY --from=fetcher /cldr /var/www/html/extensions/cldr
 
-FROM composer as composer
+FROM composer:1 as composer
 COPY --from=collector /var/www/html /var/www/html
 WORKDIR /var/www/html/
 RUN rm /var/www/html/composer.lock

--- a/wikibase/1.34/base/Dockerfile
+++ b/wikibase/1.34/base/Dockerfile
@@ -13,7 +13,7 @@ FROM mediawiki:1.34 as collector
 COPY --from=fetcher /Wikibase /var/www/html/extensions/Wikibase
 
 
-FROM composer as composer
+FROM composer:1 as composer
 COPY --from=collector /var/www/html /var/www/html
 WORKDIR /var/www/html/
 COPY composer.local.json /var/www/html/composer.local.json

--- a/wikibase/1.34/bundle/Dockerfile
+++ b/wikibase/1.34/bundle/Dockerfile
@@ -33,7 +33,7 @@ COPY --from=fetcher /UniversalLanguageSelector /var/www/html/extensions/Universa
 COPY --from=fetcher /cldr /var/www/html/extensions/cldr
 COPY --from=fetcher /EntitySchema /var/www/html/extensions/EntitySchema
 
-FROM composer as composer
+FROM composer:1 as composer
 COPY --from=collector /var/www/html /var/www/html
 WORKDIR /var/www/html/
 RUN rm /var/www/html/composer.lock

--- a/wikibase/1.35/base/Dockerfile
+++ b/wikibase/1.35/base/Dockerfile
@@ -13,7 +13,7 @@ FROM mediawiki:1.35 as collector
 COPY --from=fetcher /Wikibase /var/www/html/extensions/Wikibase
 
 
-FROM composer as composer
+FROM composer:1 as composer
 COPY --from=collector /var/www/html /var/www/html
 WORKDIR /var/www/html/
 COPY composer.local.json /var/www/html/composer.local.json

--- a/wikibase/1.35/bundle/Dockerfile
+++ b/wikibase/1.35/bundle/Dockerfile
@@ -33,7 +33,7 @@ COPY --from=fetcher /UniversalLanguageSelector /var/www/html/extensions/Universa
 COPY --from=fetcher /cldr /var/www/html/extensions/cldr
 COPY --from=fetcher /EntitySchema /var/www/html/extensions/EntitySchema
 
-FROM composer as composer
+FROM composer:1 as composer
 COPY --from=collector /var/www/html /var/www/html
 WORKDIR /var/www/html/
 RUN rm /var/www/html/composer.lock


### PR DESCRIPTION
Composer (the php dependency management tool, not the docker command), was [recently updated ](https://github.com/composer/docker/issues/132) to 2.0, and the default docker builds did so as well.

Unfortunately, there is a php library, composer-merge-plugin, that's used extensively here and that isn't (yet) compatible with composer 2.0.

If you try to to (re-)build the current images, they will fail. The docker-compose may still work because it pulls prebuilt wikibase/wikibase:1.34 and so on, but rebuilding those would fail, as does building the 1.35 that aren't available in hub.

Because people are excellent, there [is a a pull request](https://github.com/wikimedia/composer-merge-plugin/pull/189) updating this library, which would be the preferable solution here. Unfortunately, it isn't merged yet, and this fix here, namely locking the composer version to 1 is, to put it mildly, "somewhat less complex". 

Thanks!

P.S.: I've been running the 1.35 version for a while now, and haven't found anything to complain about. Is there a specific reason it's not published? 

PPS: I've been playing around with the travis builds and belatedly noticed there is a section pinging an IRC channel with build information. I have no idea where it gets its credentials from, but want to apologise for the spam if those pings went through.