### PR TITLE
Escape environment variables

### DIFF
--- a/wikibase/1.31/base/entrypoint.sh
+++ b/wikibase/1.31/base/entrypoint.sh
@@ -27,8 +27,8 @@ fi
 
 # Do the mediawiki install (only if LocalSettings doesn't already exist)
 if [ ! -e "/var/www/html/LocalSettings.php" ]; then
-    php /var/www/html/maintenance/install.php --dbuser $DB_USER --dbpass $DB_PASS --dbname $DB_NAME --dbserver $DB_SERVER --lang $MW_SITE_LANG --pass $MW_ADMIN_PASS $MW_SITE_NAME $MW_ADMIN_NAME
-    php /var/www/html/maintenance/resetUserEmail.php --no-reset-password $MW_ADMIN_NAME $MW_ADMIN_EMAIL
+    php /var/www/html/maintenance/install.php --dbuser "$DB_USER" --dbpass "$DB_PASS" --dbname "$DB_NAME" --dbserver "$DB_SERVER" --lang "$MW_SITE_LANG" --pass "$MW_ADMIN_PASS" "$MW_SITE_NAME" "$MW_ADMIN_NAME"
+    php /var/www/html/maintenance/resetUserEmail.php --no-reset-password "$MW_ADMIN_NAME" "$MW_ADMIN_EMAIL"
 
     # Copy our LocalSettings into place after install from the template
     # https://stackoverflow.com/a/24964089/4746236

--- a/wikibase/1.34/base/entrypoint.sh
+++ b/wikibase/1.34/base/entrypoint.sh
@@ -27,8 +27,8 @@ fi
 
 # Do the mediawiki install (only if LocalSettings doesn't already exist)
 if [ ! -e "/var/www/html/LocalSettings.php" ]; then
-    php /var/www/html/maintenance/install.php --dbuser $DB_USER --dbpass $DB_PASS --dbname $DB_NAME --dbserver $DB_SERVER --lang $MW_SITE_LANG --pass $MW_ADMIN_PASS $MW_SITE_NAME $MW_ADMIN_NAME
-    php /var/www/html/maintenance/resetUserEmail.php --no-reset-password $MW_ADMIN_NAME $MW_ADMIN_EMAIL
+    php /var/www/html/maintenance/install.php --dbuser "$DB_USER" --dbpass "$DB_PASS" --dbname "$DB_NAME" --dbserver "$DB_SERVER" --lang "$MW_SITE_LANG" --pass "$MW_ADMIN_PASS" "$MW_SITE_NAME" "$MW_ADMIN_NAME"
+    php /var/www/html/maintenance/resetUserEmail.php --no-reset-password "$MW_ADMIN_NAME" "$MW_ADMIN_EMAIL"
 
     # Copy our LocalSettings into place after install from the template
     # https://stackoverflow.com/a/24964089/4746236

--- a/wikibase/1.35/base/entrypoint.sh
+++ b/wikibase/1.35/base/entrypoint.sh
@@ -27,8 +27,8 @@ fi
 
 # Do the mediawiki install (only if LocalSettings doesn't already exist)
 if [ ! -e "/var/www/html/LocalSettings.php" ]; then
-    php /var/www/html/maintenance/install.php --dbuser $DB_USER --dbpass $DB_PASS --dbname $DB_NAME --dbserver $DB_SERVER --lang $MW_SITE_LANG --pass $MW_ADMIN_PASS $MW_SITE_NAME $MW_ADMIN_NAME
-    php /var/www/html/maintenance/resetUserEmail.php --no-reset-password $MW_ADMIN_NAME $MW_ADMIN_EMAIL
+    php /var/www/html/maintenance/install.php --dbuser "$DB_USER" --dbpass "$DB_PASS" --dbname "$DB_NAME" --dbserver "$DB_SERVER" --lang "$MW_SITE_LANG" --pass "$MW_ADMIN_PASS" "$MW_SITE_NAME" "$MW_ADMIN_NAME"
+    php /var/www/html/maintenance/resetUserEmail.php --no-reset-password "$MW_ADMIN_NAME" "$MW_ADMIN_EMAIL"
 
     # Copy our LocalSettings into place after install from the template
     # https://stackoverflow.com/a/24964089/4746236


### PR DESCRIPTION
This PR adds quotes to env variables in the several `entrypoint.sh` scripts. It fixes the case when defining values for env variables containing a space.

For example, when defining `MW_SITE_NAME=My Website` in `docker-compose.yml`, then the generated `/var/www/html/LocalSettings.php` is not the one derived from `/LocalSettings.php.template` via `envsubst`, but a completely new `LocalSettings.php` generated by (maybe?) MediaWiki's `install.php`.
